### PR TITLE
ci: roll out shared github-actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,53 +7,58 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    name: Lint
+    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@main
+    with:
+      otp_version: "27.3"
+      elixir_version: "1.18.4"
+      validate_hex_package: false
+
   test:
-    name: Test & Lint
+    name: Test
+    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@main
+    with:
+      otp_versions: '["27.3"]'
+      elixir_versions: '["1.18.4"]'
+      test_command: mix test
+
+  coverage:
+    name: Coverage
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        otp: ["27.3"]
-        elixir: ["1.18.4"]
-
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
+          otp-version: "27.3"
+          elixir-version: "1.18.4"
 
       - name: Restore cached deps
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
-          path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-coverage-${{ hashFiles('mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-
+            ${{ runner.os }}-coverage-
 
-      - name: Restore cached _build
-        uses: actions/cache@v3
-        with:
-          path: _build
-          key: ${{ runner.os }}-build-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
+      - name: Install Hex/Rebar
+        run: |
+          set -euo pipefail
+          mix local.hex --force
+          mix local.rebar --force
 
       - name: Install dependencies
         run: mix deps.get
 
-      - name: Check formatting
-        run: mix format --check-formatted
-
-      - name: Run Credo
-        run: mix credo --min-priority higher
-
-      - name: Run tests
+      - name: Run coverage
         run: mix test --cover
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: ./cover/excoveralls.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,35 @@
-name: Publish to Hex.pm
+name: Release
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      hex_dry_run:
+        description: "Hex dry run only (run all git/release steps, but skip actual Hex publish)"
+        required: false
+        type: boolean
+        default: false
+      skip_tests:
+        description: "Skip tests before release"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
-    name: Publish Package
-
-    strategy:
-      matrix:
-        otp: ["27.3"]
-        elixir: ["1.18.4"]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Elixir
-        uses: erlef/setup-elixir@v1
-        with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
-
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Build package
-        run: mix hex.build
-
-      - name: Publish to Hex.pm
-        run: mix hex.publish --yes
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+  release:
+    name: Release
+    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@main
+    with:
+      otp_version: "27.3"
+      elixir_version: "1.18.4"
+      dry_run: ${{ inputs.dry_run }}
+      hex_dry_run: ${{ inputs.hex_dry_run }}
+      skip_tests: ${{ inputs.skip_tests }}
+    secrets: inherit

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,33 @@
 import Config
 
+if config_env() == :dev do
+  config :git_hooks,
+    auto_install: true,
+    verbose: true,
+    hooks: [
+      commit_msg: [
+        tasks: [
+          {:cmd, "mix git_ops.check_message", include_hook_args: true}
+        ]
+      ]
+    ]
+
+  config :git_ops,
+    mix_project: Jido.Messaging.MixProject,
+    changelog_file: "CHANGELOG.md",
+    repository_url: "https://github.com/agentjido/jido_messaging",
+    manage_mix_version?: true,
+    version_tag_prefix: "v",
+    types: [
+      feat: [header: "Features"],
+      fix: [header: "Bug Fixes"],
+      perf: [header: "Performance"],
+      refactor: [header: "Refactoring"],
+      docs: [hidden?: true],
+      test: [hidden?: true],
+      chore: [hidden?: true],
+      ci: [hidden?: true]
+    ]
+end
+
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
## Summary
- move the repo onto the shared `agentjido/github-actions` lint and test workflows
- move release automation onto the shared git_ops-based release workflow
- add the minimal `git_ops` configuration needed for the shared release flow where this repo did not already have it

## Notes
- repo-specific extra jobs were only kept where they are part of the current CI contract
- this rollout intentionally avoids the known edge-case repos (`llm_db`, `jido_run`, browser/shell special cases, and the no-workflow repos)
