### PR TITLE
[codex] fix: clear Elixir 1.20 compile warnings

### DIFF
--- a/lib/jido_messaging/dead_letter.ex
+++ b/lib/jido_messaging/dead_letter.ex
@@ -25,7 +25,7 @@ defmodule Jido.Messaging.DeadLetter do
           last_result: term() | nil
         }
 
-  @type record :: %{
+  @type dead_letter_record :: %{
           id: String.t(),
           instance_module: module(),
           status: record_status(),
@@ -48,13 +48,13 @@ defmodule Jido.Messaging.DeadLetter do
         }
 
   @type replay_response ::
-          %{status: :already_replayed, record: record()}
-          | %{status: :replayed, response: OutboundGateway.success_response(), record: record()}
+          %{status: :already_replayed, record: dead_letter_record()}
+          | %{status: :replayed, response: OutboundGateway.success_response(), record: dead_letter_record()}
 
   @type state :: %{
           instance_module: module(),
           max_records: pos_integer(),
-          records: %{optional(String.t()) => record()},
+          records: %{optional(String.t()) => dead_letter_record()},
           order: [String.t()]
         }
 
@@ -108,7 +108,7 @@ defmodule Jido.Messaging.DeadLetter do
   @doc """
   Capture a terminal outbound failure into dead-letter storage.
   """
-  @spec capture_outbound_failure(module(), map(), map(), map()) :: {:ok, record()} | {:error, :unavailable}
+  @spec capture_outbound_failure(module(), map(), map(), map()) :: {:ok, dead_letter_record()} | {:error, :unavailable}
   def capture_outbound_failure(instance_module, request, error, diagnostics \\ %{})
       when is_atom(instance_module) and is_map(request) and is_map(error) and is_map(diagnostics) do
     call(instance_module, {:capture_outbound_failure, request, error, diagnostics})
@@ -121,7 +121,7 @@ defmodule Jido.Messaging.DeadLetter do
   - `:status` - `:active`, `:archived`, or `:all` (default: `:all`)
   - `:limit` - positive integer limit
   """
-  @spec list(module(), keyword()) :: {:ok, [record()]} | {:error, :unavailable}
+  @spec list(module(), keyword()) :: {:ok, [dead_letter_record()]} | {:error, :unavailable}
   def list(instance_module, opts \\ []) when is_atom(instance_module) and is_list(opts) do
     call(instance_module, {:list, opts})
   end
@@ -129,7 +129,7 @@ defmodule Jido.Messaging.DeadLetter do
   @doc """
   Get a dead-letter record by id.
   """
-  @spec get(module(), String.t()) :: {:ok, record()} | {:error, :not_found | :unavailable}
+  @spec get(module(), String.t()) :: {:ok, dead_letter_record()} | {:error, :not_found | :unavailable}
   def get(instance_module, dead_letter_id) when is_atom(instance_module) and is_binary(dead_letter_id) do
     call(instance_module, {:get, dead_letter_id})
   end
@@ -166,7 +166,8 @@ defmodule Jido.Messaging.DeadLetter do
 
   @doc false
   @spec prepare_replay(module(), String.t(), boolean()) ::
-          {:ok, :replay | :already_replayed, record()} | {:error, :not_found | :archived | :replay_in_progress}
+          {:ok, :replay | :already_replayed, dead_letter_record()}
+          | {:error, :not_found | :archived | :replay_in_progress}
   def prepare_replay(instance_module, dead_letter_id, force? \\ false)
       when is_atom(instance_module) and is_binary(dead_letter_id) and is_boolean(force?) do
     call(instance_module, {:prepare_replay, dead_letter_id, force?})
@@ -174,7 +175,7 @@ defmodule Jido.Messaging.DeadLetter do
 
   @doc false
   @spec complete_replay(module(), String.t(), {:ok, term()} | {:error, term()}) ::
-          {:ok, record()} | {:error, :not_found | :unavailable}
+          {:ok, dead_letter_record()} | {:error, :not_found | :unavailable}
   def complete_replay(instance_module, dead_letter_id, replay_result)
       when is_atom(instance_module) and is_binary(dead_letter_id) do
     call(instance_module, {:complete_replay, dead_letter_id, replay_result})

--- a/lib/jido_messaging/deduper.ex
+++ b/lib/jido_messaging/deduper.ex
@@ -14,7 +14,6 @@ defmodule Jido.Messaging.Deduper do
       end
   """
   use GenServer
-  require Logger
 
   @default_ttl_ms :timer.hours(1)
   @sweep_interval_ms :timer.minutes(1)

--- a/lib/jido_messaging/demo/bridge.ex
+++ b/lib/jido_messaging/demo/bridge.ex
@@ -309,6 +309,9 @@ defmodule Jido.Messaging.Demo.Bridge do
     normalize_module(module)
   end
 
+  defp normalize_module(nil),
+    do: raise(ArgumentError, "missing adapter module configuration (set opts or env)")
+
   defp normalize_module(module) when is_atom(module), do: module
 
   defp normalize_module(module_name) when is_binary(module_name) and module_name != "" do
@@ -316,9 +319,6 @@ defmodule Jido.Messaging.Demo.Bridge do
     |> String.split(".")
     |> Module.concat()
   end
-
-  defp normalize_module(nil),
-    do: raise(ArgumentError, "missing adapter module configuration (set opts or env)")
 
   defp normalize_module(other),
     do: raise(ArgumentError, "invalid adapter module configuration: #{inspect(other)}")

--- a/lib/jido_messaging/inbound_router.ex
+++ b/lib/jido_messaging/inbound_router.ex
@@ -423,8 +423,6 @@ defmodule Jido.Messaging.InboundRouter do
     end
   end
 
-  defp event_envelope_shape?(%EventEnvelope{}), do: true
-
   defp event_envelope_shape?(map) when is_map(map) do
     Map.has_key?(map, :event_type) or Map.has_key?(map, "event_type")
   end

--- a/lib/jido_messaging/instance_server.ex
+++ b/lib/jido_messaging/instance_server.ex
@@ -22,7 +22,6 @@ defmodule Jido.Messaging.InstanceServer do
   - `[:jido_messaging, :instance, :error]`
   """
   use GenServer
-  require Logger
 
   alias Jido.Messaging.Instance
 

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -440,10 +440,6 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
      })}
   end
 
-  defp media_text_fallback(_request, _fallback_text, _metadata) do
-    {:error, :unsupported_media_fallback}
-  end
-
   defp media_policy_opts(opts) when is_list(opts) do
     case Keyword.get(opts, :media_policy, []) do
       value when is_list(value) -> value

--- a/lib/jido_messaging/runtime.ex
+++ b/lib/jido_messaging/runtime.ex
@@ -6,7 +6,6 @@ defmodule Jido.Messaging.Runtime do
   adapter module and adapter state (e.g., ETS table references).
   """
   use GenServer
-  require Logger
 
   @schema Zoi.struct(
             __MODULE__,


### PR DESCRIPTION
## Summary

- Rename the dead-letter `record` type so it no longer collides with the Elixir built-in type.
- Remove unused Logger requirements and unreachable private helper clauses flagged by Elixir 1.20.
- Keep the change scoped to compile-warning cleanup for the Dependabot rebase path.

## Validation

- Toolchain: Erlang/OTP 29.0.1, Elixir 1.20.0
- `MIX_ENV=test mix compile --warnings-as-errors`