### PR TITLE
fix: make inbound deduplication commit-aware

### DIFF
--- a/lib/jido_messaging/deduper.ex
+++ b/lib/jido_messaging/deduper.ex
@@ -2,8 +2,9 @@ defmodule Jido.Messaging.Deduper do
   @moduledoc """
   Central message deduplication using ETS with TTL.
 
-  Prevents duplicate processing of inbound messages by tracking seen message keys.
-  Keys expire after a configurable TTL and are periodically swept.
+  Prevents duplicate processing of inbound messages by tracking claimed and
+  completed message keys. Keys expire after a configurable TTL and are
+  periodically swept.
 
   ## Usage
 
@@ -37,6 +38,7 @@ defmodule Jido.Messaging.Deduper do
   def schema, do: @schema
 
   @type key :: term()
+  @type claim_token :: reference()
 
   # Client API
 
@@ -54,6 +56,33 @@ defmodule Jido.Messaging.Deduper do
   def check_and_mark(messaging_module, key, ttl_ms \\ nil) do
     deduper = deduper_name(messaging_module)
     GenServer.call(deduper, {:check_and_mark, key, ttl_ms})
+  end
+
+  @doc """
+  Atomically claim a key before processing starts.
+
+  Returns `{:ok, token}` for a new or expired key and `:duplicate` while a
+  current claim or completed mark exists. The caller must pass the token to
+  `commit/4` after successful processing or to `release/3` after a failure.
+  """
+  @spec claim(module(), key(), non_neg_integer() | nil) :: {:ok, claim_token()} | :duplicate
+  def claim(messaging_module, key, ttl_ms \\ nil) do
+    deduper = deduper_name(messaging_module)
+    GenServer.call(deduper, {:claim, key, ttl_ms})
+  end
+
+  @doc "Commit a claimed key as completed."
+  @spec commit(module(), key(), claim_token(), non_neg_integer() | nil) :: :ok | {:error, :stale_claim}
+  def commit(messaging_module, key, token, ttl_ms \\ nil) when is_reference(token) do
+    deduper = deduper_name(messaging_module)
+    GenServer.call(deduper, {:commit, key, token, ttl_ms})
+  end
+
+  @doc "Release a failed claim so that the key can be retried."
+  @spec release(module(), key(), claim_token()) :: :ok | {:error, :stale_claim}
+  def release(messaging_module, key, token) when is_reference(token) do
+    deduper = deduper_name(messaging_module)
+    GenServer.call(deduper, {:release, key, token})
   end
 
   @doc """
@@ -123,13 +152,54 @@ defmodule Jido.Messaging.Deduper do
     ttl = custom_ttl || state.ttl_ms
     expires_at = now + ttl
 
-    case :ets.lookup(state.table, key) do
-      [{^key, exp}] when exp > now ->
+    case lookup_current(state.table, key, now) do
+      {:current, _entry} ->
         {:reply, :duplicate, state}
 
-      _ ->
-        :ets.insert(state.table, {key, expires_at})
+      :expired_or_missing ->
+        :ets.insert(state.table, {key, :seen, expires_at})
         {:reply, :new, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:claim, key, custom_ttl}, _from, state) do
+    now = System.monotonic_time(:millisecond)
+    ttl = custom_ttl || state.ttl_ms
+
+    case lookup_current(state.table, key, now) do
+      {:current, _entry} ->
+        {:reply, :duplicate, state}
+
+      :expired_or_missing ->
+        token = make_ref()
+        :ets.insert(state.table, {key, :claimed, token, now + ttl})
+        {:reply, {:ok, token}, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:commit, key, token, custom_ttl}, _from, state) do
+    case :ets.lookup(state.table, key) do
+      [{^key, :claimed, ^token, _expires_at}] ->
+        ttl = custom_ttl || state.ttl_ms
+        :ets.insert(state.table, {key, :seen, System.monotonic_time(:millisecond) + ttl})
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, {:error, :stale_claim}, state}
+    end
+  end
+
+  @impl true
+  def handle_call({:release, key, token}, _from, state) do
+    case :ets.lookup(state.table, key) do
+      [{^key, :claimed, ^token, _expires_at}] ->
+        :ets.delete(state.table, key)
+        {:reply, :ok, state}
+
+      _ ->
+        {:reply, {:error, :stale_claim}, state}
     end
   end
 
@@ -138,10 +208,7 @@ defmodule Jido.Messaging.Deduper do
     now = System.monotonic_time(:millisecond)
 
     result =
-      case :ets.lookup(state.table, key) do
-        [{^key, exp}] when exp > now -> true
-        _ -> false
-      end
+      match?({:current, _entry}, lookup_current(state.table, key, now))
 
     {:reply, result, state}
   end
@@ -152,7 +219,7 @@ defmodule Jido.Messaging.Deduper do
     ttl = custom_ttl || state.ttl_ms
     expires_at = now + ttl
 
-    :ets.insert(state.table, {key, expires_at})
+    :ets.insert(state.table, {key, :seen, expires_at})
     {:reply, :ok, state}
   end
 
@@ -182,8 +249,9 @@ defmodule Jido.Messaging.Deduper do
     now = System.monotonic_time(:millisecond)
 
     :ets.foldl(
-      fn {key, expires_at}, acc ->
-        if expires_at <= now do
+      fn entry, acc ->
+        if entry_expires_at(entry) <= now do
+          key = elem(entry, 0)
           :ets.delete(table, key)
         end
 
@@ -193,4 +261,15 @@ defmodule Jido.Messaging.Deduper do
       table
     )
   end
+
+  defp lookup_current(table, key, now) do
+    case :ets.lookup(table, key) do
+      [{^key, :seen, expires_at} = entry] when expires_at > now -> {:current, entry}
+      [{^key, :claimed, _token, expires_at} = entry] when expires_at > now -> {:current, entry}
+      _ -> :expired_or_missing
+    end
+  end
+
+  defp entry_expires_at({_key, :seen, expires_at}), do: expires_at
+  defp entry_expires_at({_key, :claimed, _token, expires_at}), do: expires_at
 end

--- a/lib/jido_messaging/deduper.ex
+++ b/lib/jido_messaging/deduper.ex
@@ -64,6 +64,10 @@ defmodule Jido.Messaging.Deduper do
   Returns `{:ok, token}` for a new or expired key and `:duplicate` while a
   current claim or completed mark exists. The caller must pass the token to
   `commit/4` after successful processing or to `release/3` after a failure.
+
+  Claims and completed marks are process-local ETS data. They are lost when
+  the messaging runtime restarts, so this module does not provide durable or
+  cross-node deduplication.
   """
   @spec claim(module(), key(), non_neg_integer() | nil) :: {:ok, claim_token()} | :duplicate
   def claim(messaging_module, key, ttl_ms \\ nil) do

--- a/lib/jido_messaging/ingest.ex
+++ b/lib/jido_messaging/ingest.ex
@@ -95,14 +95,8 @@ defmodule Jido.Messaging.Ingest do
     bridge_id = to_string(bridge_id)
     external_room_id = incoming.external_room_id
 
-    dedupe_key = build_dedupe_key(channel_type, bridge_id, incoming)
-
-    case Jido.Messaging.Deduper.check_and_mark(messaging_module, dedupe_key) do
-      :duplicate ->
-        Logger.debug("[Jido.Messaging.Ingest] Duplicate message ignored: #{inspect(dedupe_key)}")
-        {:ok, :duplicate}
-
-      :new ->
+    case build_dedupe_key(channel_type, bridge_id, incoming) do
+      :skip ->
         do_ingest(
           messaging_module,
           channel_module,
@@ -112,7 +106,64 @@ defmodule Jido.Messaging.Ingest do
           incoming,
           opts
         )
+
+      {:ok, dedupe_key} ->
+        ingest_with_dedupe_claim(
+          messaging_module,
+          channel_module,
+          channel_type,
+          bridge_id,
+          external_room_id,
+          incoming,
+          opts,
+          dedupe_key
+        )
     end
+  end
+
+  defp ingest_with_dedupe_claim(
+         messaging_module,
+         channel_module,
+         channel_type,
+         bridge_id,
+         external_room_id,
+         incoming,
+         opts,
+         dedupe_key
+       ) do
+    case Jido.Messaging.Deduper.claim(messaging_module, dedupe_key) do
+      :duplicate ->
+        Logger.debug("[Jido.Messaging.Ingest] Duplicate message ignored: #{inspect(dedupe_key)}")
+        {:ok, :duplicate}
+
+      {:ok, claim_token} ->
+        result =
+          do_ingest(
+            messaging_module,
+            channel_module,
+            channel_type,
+            bridge_id,
+            external_room_id,
+            incoming,
+            opts
+          )
+
+        finalize_dedupe_claim(messaging_module, dedupe_key, claim_token, result)
+    end
+  end
+
+  defp finalize_dedupe_claim(messaging_module, dedupe_key, claim_token, {:ok, _message, _context} = result) do
+    case Jido.Messaging.Deduper.commit(messaging_module, dedupe_key, claim_token) do
+      :ok -> :ok
+      {:error, :stale_claim} -> Logger.warning("[Jido.Messaging.Ingest] Dedupe claim expired before commit")
+    end
+
+    result
+  end
+
+  defp finalize_dedupe_claim(messaging_module, dedupe_key, claim_token, {:error, _reason} = result) do
+    _ = Jido.Messaging.Deduper.release(messaging_module, dedupe_key, claim_token)
+    result
   end
 
   @doc """
@@ -262,8 +313,15 @@ defmodule Jido.Messaging.Ingest do
     external_message_id = Map.get(incoming, :external_message_id)
     external_room_id = Map.get(incoming, :external_room_id)
 
-    {channel_type, bridge_id, external_room_id, external_message_id}
+    if usable_external_id?(external_message_id) do
+      {:ok, {channel_type, bridge_id, to_string(external_room_id), to_string(external_message_id)}}
+    else
+      :skip
+    end
   end
+
+  defp usable_external_id?(external_id) when is_binary(external_id), do: String.trim(external_id) != ""
+  defp usable_external_id?(external_id), do: not is_nil(external_id)
 
   # Private helpers
 

--- a/test/jido_messaging/deduper_test.exs
+++ b/test/jido_messaging/deduper_test.exs
@@ -49,6 +49,35 @@ defmodule Jido.Messaging.DeduperTest do
     end
   end
 
+  describe "claim lifecycle" do
+    test "blocks a concurrent claim until the first claim is released" do
+      key = {:claim, "release"}
+
+      assert {:ok, token} = Deduper.claim(TestMessaging, key)
+      assert :duplicate = Deduper.claim(TestMessaging, key)
+      assert :ok = Deduper.release(TestMessaging, key, token)
+      assert {:ok, _new_token} = Deduper.claim(TestMessaging, key)
+    end
+
+    test "keeps a committed claim as a duplicate" do
+      key = {:claim, "commit"}
+
+      assert {:ok, token} = Deduper.claim(TestMessaging, key)
+      assert :ok = Deduper.commit(TestMessaging, key, token)
+      assert :duplicate = Deduper.claim(TestMessaging, key)
+    end
+
+    test "does not let an old token release a newer claim" do
+      key = {:claim, "stale"}
+
+      assert {:ok, old_token} = Deduper.claim(TestMessaging, key, 1)
+      Process.sleep(2)
+      assert {:ok, new_token} = Deduper.claim(TestMessaging, key)
+      assert {:error, :stale_claim} = Deduper.release(TestMessaging, key, old_token)
+      assert :ok = Deduper.commit(TestMessaging, key, new_token)
+    end
+  end
+
   describe "mark_seen/3" do
     test "marks a key as seen" do
       key = {:mark, "test"}

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -7,6 +7,33 @@ defmodule Jido.Messaging.IngestTest do
     use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
   end
 
+  defmodule FailOncePersistence do
+    alias Jido.Messaging.Persistence.ETS
+
+    def init(opts), do: ETS.init(opts)
+    def list_bridge_configs(state, opts), do: ETS.list_bridge_configs(state, opts)
+
+    def get_or_create_room_by_external_binding(state, channel, bridge_id, external_id, attrs),
+      do: ETS.get_or_create_room_by_external_binding(state, channel, bridge_id, external_id, attrs)
+
+    def get_or_create_participant_by_external_id(state, channel, external_id, attrs),
+      do: ETS.get_or_create_participant_by_external_id(state, channel, external_id, attrs)
+
+    def get_message_by_external_id(state, channel, bridge_id, external_id),
+      do: ETS.get_message_by_external_id(state, channel, bridge_id, external_id)
+
+    def save_message(state, message) do
+      Agent.get_and_update(__MODULE__.Switch, fn
+        :fail -> {{:error, :temporary_storage_failure}, :pass}
+        :pass -> {ETS.save_message(state, message), :pass}
+      end)
+    end
+  end
+
+  defmodule FailureMessaging do
+    use Jido.Messaging, persistence: FailOncePersistence
+  end
+
   defmodule MockChannel do
     @behaviour Jido.Chat.Adapter
 
@@ -240,6 +267,27 @@ defmodule Jido.Messaging.IngestTest do
       assert Enum.map(messages, &hd(&1.content).text) == ["First", "Second"]
     end
 
+    test "does not dedupe empty or whitespace-only provider message IDs" do
+      base = %{
+        external_room_id: "chat_with_empty_message_ids",
+        external_user_id: "user_with_empty_message_ids",
+        text: "Empty ID",
+        external_message_id: ""
+      }
+
+      assert {:ok, first_message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "empty_id_inst", base)
+
+      assert {:ok, second_message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "empty_id_inst", %{
+                 base
+                 | text: "Whitespace ID",
+                   external_message_id: "   "
+               })
+
+      refute first_message.id == second_message.id
+    end
+
     test "releases the dedupe claim after a temporary ingest failure" do
       incoming = %{
         external_room_id: "chat_retry_after_failure",
@@ -258,6 +306,51 @@ defmodule Jido.Messaging.IngestTest do
 
       assert {:ok, :duplicate} =
                Ingest.ingest_incoming(TestMessaging, MockChannel, "retry_inst", incoming)
+    end
+
+    test "releases the dedupe claim after a persistence failure" do
+      start_supervised!(%{
+        id: FailOncePersistence.Switch,
+        start: {Agent, :start_link, [fn -> :fail end, [name: FailOncePersistence.Switch]]}
+      })
+
+      start_supervised!(FailureMessaging)
+
+      incoming = %{
+        external_room_id: "chat_retry_storage_failure",
+        external_user_id: "user_retry_storage_failure",
+        text: "Retry storage",
+        external_message_id: "provider-storage-message-1"
+      }
+
+      assert {:error, :temporary_storage_failure} =
+               Ingest.ingest_incoming(FailureMessaging, MockChannel, "storage_retry_inst", incoming)
+
+      assert {:ok, message, _context} =
+               Ingest.ingest_incoming(FailureMessaging, MockChannel, "storage_retry_inst", incoming)
+
+      assert message.external_id == "provider-storage-message-1"
+    end
+
+    test "accepts one copy during concurrent delivery of one provider event" do
+      incoming = %{
+        external_room_id: "chat_concurrent_dedupe",
+        external_user_id: "user_concurrent_dedupe",
+        text: "Only once",
+        external_message_id: "provider-concurrent-message-1"
+      }
+
+      results =
+        1..20
+        |> Task.async_stream(
+          fn _index -> Ingest.ingest_incoming(TestMessaging, MockChannel, "concurrent_inst", incoming) end,
+          ordered: false,
+          timeout: 5_000
+        )
+        |> Enum.map(fn {:ok, result} -> result end)
+
+      assert Enum.count(results, &match?({:ok, %Jido.Messaging.Message{}, _context}, &1)) == 1
+      assert Enum.count(results, &(&1 == {:ok, :duplicate})) == 19
     end
 
     test "reuses existing room for same external binding" do

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -219,6 +219,47 @@ defmodule Jido.Messaging.IngestTest do
       assert is_atom(context.instance_module)
     end
 
+    test "accepts different messages when the provider does not supply message IDs" do
+      first = %{
+        external_room_id: "chat_without_message_ids",
+        external_user_id: "user_without_message_ids",
+        text: "First",
+        external_message_id: nil
+      }
+
+      second = %{first | text: "Second"}
+
+      assert {:ok, first_message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "no_id_inst", first)
+
+      assert {:ok, second_message, context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "no_id_inst", second)
+
+      refute first_message.id == second_message.id
+      assert {:ok, messages} = TestMessaging.list_messages(context.room.id)
+      assert Enum.map(messages, &hd(&1.content).text) == ["First", "Second"]
+    end
+
+    test "releases the dedupe claim after a temporary ingest failure" do
+      incoming = %{
+        external_room_id: "chat_retry_after_failure",
+        external_user_id: "user_retry_after_failure",
+        text: "Retry me",
+        external_message_id: "provider-message-1"
+      }
+
+      assert {:error, {:policy_denied, :gating, :denied, "Denied by gater"}} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "retry_inst", incoming, gaters: [DenyGater])
+
+      assert {:ok, message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "retry_inst", incoming)
+
+      assert message.external_id == "provider-message-1"
+
+      assert {:ok, :duplicate} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "retry_inst", incoming)
+    end
+
     test "reuses existing room for same external binding" do
       incoming = %{
         external_room_id: "chat_same",


### PR DESCRIPTION
## Summary

- add an atomic dedupe claim, commit, and release lifecycle
- release claims after ingest failures so provider retries can run
- bypass dedupe when the provider does not supply a usable message ID
- preserve duplicate blocking during concurrent work

## Verification

- `mix test test/jido_messaging/deduper_test.exs test/jido_messaging/ingest_test.exs`
- `mix test` — 541 passed, 4 skipped, 13 excluded

Closes #45