### PR TITLE
fix: apply selected bridge configuration to adapter calls

### DIFF
--- a/lib/jido_messaging/bridge_config.ex
+++ b/lib/jido_messaging/bridge_config.ex
@@ -62,6 +62,20 @@ defmodule Jido.Messaging.BridgeConfig do
     %{config | revision: config.revision + 1, updated_at: DateTime.utc_now()}
   end
 
+  @doc """
+  Adds the selected bridge context to adapter call options.
+
+  Call-specific options have precedence. This lets a caller make an explicit
+  override without changing the stored bridge configuration.
+  """
+  @spec adapter_opts(t(), keyword()) :: keyword()
+  def adapter_opts(%__MODULE__{} = config, opts \\ []) when is_list(opts) do
+    opts
+    |> Keyword.put_new(:bridge_config, config)
+    |> Keyword.put_new(:credentials, config.credentials)
+    |> Keyword.put_new(:settings, config.opts)
+  end
+
   defp normalize_attrs(attrs) do
     attrs
     |> Enum.reduce(%{}, fn

--- a/lib/jido_messaging/inbound_router.ex
+++ b/lib/jido_messaging/inbound_router.ex
@@ -86,13 +86,14 @@ defmodule Jido.Messaging.InboundRouter do
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
          :ok <- ensure_enabled(config),
          {:ok, adapter_module} <- ensure_adapter_module(config) do
+      adapter_opts = BridgeConfig.adapter_opts(config, opts)
       request = build_webhook_request(adapter_module, payload, request_meta)
-      format_opts = Keyword.merge(opts, request: request)
+      format_opts = Keyword.put(adapter_opts, :request, request)
 
       outcome =
-        with :ok <- Adapter.verify_webhook(adapter_module, request, opts),
-             {:ok, event} <- Adapter.parse_event(adapter_module, request, opts) do
-          dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, opts)
+        with :ok <- Adapter.verify_webhook(adapter_module, request, adapter_opts),
+             {:ok, event} <- Adapter.parse_event(adapter_module, request, adapter_opts) do
+          dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, adapter_opts)
         end
 
       response =
@@ -118,13 +119,15 @@ defmodule Jido.Messaging.InboundRouter do
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
          :ok <- ensure_enabled(config),
          {:ok, adapter_module} <- ensure_adapter_module(config) do
+      adapter_opts = BridgeConfig.adapter_opts(config, opts)
+
       outcome =
-        case normalize_payload_event(adapter_module, payload, opts) do
+        case normalize_payload_event(adapter_module, payload, adapter_opts) do
           {:ok, :noop} ->
             {:ok, :noop}
 
           {:ok, %EventEnvelope{} = event} ->
-            dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, opts)
+            dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, adapter_opts)
 
           :fallback ->
             with {:ok, incoming} <- Adapter.transform_incoming(adapter_module, payload) do
@@ -140,7 +143,7 @@ defmodule Jido.Messaging.InboundRouter do
                   metadata: %{source: :payload, bridge_id: bridge_id}
                 })
 
-              dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, opts)
+              dispatch_event(instance_module, adapter_module, bridge_id, event, ingest_opts, adapter_opts)
             end
         end
 

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -278,9 +278,13 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     |> maybe_put(:media, operation_metadata[:media])
   end
 
-  defp perform_operation(instance_module, %{operation: :send} = request) do
-    adapter_opts = adapter_opts(instance_module, request)
+  defp perform_operation(instance_module, request) do
+    with {:ok, adapter_opts} <- adapter_opts(instance_module, request) do
+      perform_operation_with_opts(instance_module, request, adapter_opts)
+    end
+  end
 
+  defp perform_operation_with_opts(instance_module, %{operation: :send} = request, adapter_opts) do
     with {:ok, sanitized_payload, security_result} <-
            Security.sanitize_outbound(instance_module, request.channel, request.payload, adapter_opts),
          {:ok, provider_result} <-
@@ -296,9 +300,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     end
   end
 
-  defp perform_operation(instance_module, %{operation: :edit} = request) do
-    adapter_opts = adapter_opts(instance_module, request)
-
+  defp perform_operation_with_opts(instance_module, %{operation: :edit} = request, adapter_opts) do
     with {:ok, sanitized_payload, security_result} <-
            Security.sanitize_outbound(instance_module, request.channel, request.payload, adapter_opts),
          {:ok, provider_result} <-
@@ -315,9 +317,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     end
   end
 
-  defp perform_operation(instance_module, %{operation: :send_media} = request) do
-    adapter_opts = adapter_opts(instance_module, request)
-
+  defp perform_operation_with_opts(instance_module, %{operation: :send_media} = request, adapter_opts) do
     case media_preflight(request) do
       {:ok_media, payload, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
@@ -354,9 +354,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     end
   end
 
-  defp perform_operation(instance_module, %{operation: :edit_media} = request) do
-    adapter_opts = adapter_opts(instance_module, request)
-
+  defp perform_operation_with_opts(instance_module, %{operation: :edit_media} = request, adapter_opts) do
     case media_preflight(request) do
       {:ok_media, payload, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
@@ -395,14 +393,20 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     end
   end
 
-  defp perform_operation(_instance_module, %{operation: operation}) do
+  defp perform_operation_with_opts(_instance_module, %{operation: operation}, _adapter_opts) do
     {:error, {:unsupported_operation, operation}}
   end
 
   defp adapter_opts(instance_module, request) do
     case ConfigStore.get_bridge_config(instance_module, request.bridge_id) do
-      {:ok, %BridgeConfig{} = config} -> BridgeConfig.adapter_opts(config, request.opts)
-      {:error, :not_found} -> request.opts
+      {:ok, %BridgeConfig{adapter_module: adapter_module} = config} when adapter_module == request.channel ->
+        {:ok, BridgeConfig.adapter_opts(config, request.opts)}
+
+      {:ok, %BridgeConfig{adapter_module: adapter_module}} ->
+        {:error, {:bridge_adapter_mismatch, request.bridge_id, adapter_module, request.channel}}
+
+      {:error, :not_found} ->
+        {:ok, request.opts}
     end
   end
 

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -9,6 +9,8 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   @dialyzer {:nowarn_function, media_text_fallback: 3}
 
   alias Jido.Messaging.AdapterBridge
+  alias Jido.Messaging.BridgeConfig
+  alias Jido.Messaging.ConfigStore
   alias Jido.Messaging.DeadLetter
   alias Jido.Messaging.MediaPolicy
   alias Jido.Messaging.OutboundGateway
@@ -277,15 +279,17 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   end
 
   defp perform_operation(instance_module, %{operation: :send} = request) do
+    adapter_opts = adapter_opts(instance_module, request)
+
     with {:ok, sanitized_payload, security_result} <-
-           Security.sanitize_outbound(instance_module, request.channel, request.payload, request.opts),
+           Security.sanitize_outbound(instance_module, request.channel, request.payload, adapter_opts),
          {:ok, provider_result} <-
            invoke_channel(fn ->
              AdapterBridge.send_message(
                request.channel,
                request.external_room_id,
                sanitized_payload,
-               request.opts
+               adapter_opts
              )
            end) do
       {:ok, provider_result, security_result}
@@ -293,8 +297,10 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   end
 
   defp perform_operation(instance_module, %{operation: :edit} = request) do
+    adapter_opts = adapter_opts(instance_module, request)
+
     with {:ok, sanitized_payload, security_result} <-
-           Security.sanitize_outbound(instance_module, request.channel, request.payload, request.opts),
+           Security.sanitize_outbound(instance_module, request.channel, request.payload, adapter_opts),
          {:ok, provider_result} <-
            invoke_channel(fn ->
              AdapterBridge.edit_message(
@@ -302,7 +308,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
                request.external_room_id,
                request.external_message_id,
                sanitized_payload,
-               request.opts
+               adapter_opts
              )
            end) do
       {:ok, provider_result, security_result}
@@ -310,17 +316,19 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   end
 
   defp perform_operation(instance_module, %{operation: :send_media} = request) do
+    adapter_opts = adapter_opts(instance_module, request)
+
     case media_preflight(request) do
       {:ok_media, payload, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
-               Security.sanitize_outbound(instance_module, request.channel, payload, request.opts),
+               Security.sanitize_outbound(instance_module, request.channel, payload, adapter_opts),
              {:ok, provider_result} <-
                invoke_channel(fn ->
                  AdapterBridge.send_media(
                    request.channel,
                    request.external_room_id,
                    sanitized_payload,
-                   request.opts
+                   adapter_opts
                  )
                end) do
           {:ok, provider_result, security_result, %{media: media_metadata}}
@@ -328,14 +336,14 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
 
       {:fallback_text, fallback_text, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
-               Security.sanitize_outbound(instance_module, request.channel, fallback_text, request.opts),
+               Security.sanitize_outbound(instance_module, request.channel, fallback_text, adapter_opts),
              {:ok, provider_result} <-
                invoke_channel(fn ->
                  AdapterBridge.send_message(
                    request.channel,
                    request.external_room_id,
                    sanitized_payload,
-                   request.opts
+                   adapter_opts
                  )
                end) do
           {:ok, provider_result, security_result, %{media: media_metadata}}
@@ -347,10 +355,12 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   end
 
   defp perform_operation(instance_module, %{operation: :edit_media} = request) do
+    adapter_opts = adapter_opts(instance_module, request)
+
     case media_preflight(request) do
       {:ok_media, payload, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
-               Security.sanitize_outbound(instance_module, request.channel, payload, request.opts),
+               Security.sanitize_outbound(instance_module, request.channel, payload, adapter_opts),
              {:ok, provider_result} <-
                invoke_channel(fn ->
                  AdapterBridge.edit_media(
@@ -358,7 +368,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
                    request.external_room_id,
                    request.external_message_id,
                    sanitized_payload,
-                   request.opts
+                   adapter_opts
                  )
                end) do
           {:ok, provider_result, security_result, %{media: media_metadata}}
@@ -366,7 +376,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
 
       {:fallback_text, fallback_text, media_metadata} ->
         with {:ok, sanitized_payload, security_result} <-
-               Security.sanitize_outbound(instance_module, request.channel, fallback_text, request.opts),
+               Security.sanitize_outbound(instance_module, request.channel, fallback_text, adapter_opts),
              {:ok, provider_result} <-
                invoke_channel(fn ->
                  AdapterBridge.edit_message(
@@ -374,7 +384,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
                    request.external_room_id,
                    request.external_message_id,
                    sanitized_payload,
-                   request.opts
+                   adapter_opts
                  )
                end) do
           {:ok, provider_result, security_result, %{media: media_metadata}}
@@ -387,6 +397,13 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
 
   defp perform_operation(_instance_module, %{operation: operation}) do
     {:error, {:unsupported_operation, operation}}
+  end
+
+  defp adapter_opts(instance_module, request) do
+    case ConfigStore.get_bridge_config(instance_module, request.bridge_id) do
+      {:ok, %BridgeConfig{} = config} -> BridgeConfig.adapter_opts(config, request.opts)
+      {:error, :not_found} -> request.opts
+    end
   end
 
   defp media_preflight(request) do

--- a/test/jido_messaging/inbound_router_test.exs
+++ b/test/jido_messaging/inbound_router_test.exs
@@ -86,6 +86,38 @@ defmodule Jido.Messaging.InboundRouterTest do
     end
   end
 
+  defmodule ConfigAwareAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :config_aware
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, _text, _opts), do: {:error, :not_implemented}
+
+    @impl true
+    def verify_webhook(%WebhookRequest{} = request, opts) do
+      credentials = Keyword.fetch!(opts, :credentials)
+
+      if request.headers["authorization"] == credentials.token do
+        :ok
+      else
+        {:error, :invalid_signature}
+      end
+    end
+
+    @impl true
+    def parse_event(%WebhookRequest{}, opts) do
+      case Keyword.fetch!(opts, :settings) do
+        %{parse_result: :noop} -> {:ok, :noop}
+        _settings -> {:error, :invalid_settings}
+      end
+    end
+  end
+
   defmodule TestMessaging do
     use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
   end
@@ -154,6 +186,32 @@ defmodule Jido.Messaging.InboundRouterTest do
   end
 
   describe "route_webhook/4" do
+    test "uses credentials and settings from the selected bridge" do
+      {:ok, _bridge} =
+        TestMessaging.put_bridge_config(%{
+          id: "bridge_config_aware",
+          adapter_module: ConfigAwareAdapter,
+          credentials: %{token: "bridge-secret"},
+          opts: %{parse_result: :noop}
+        })
+
+      assert {:ok, :noop} =
+               InboundRouter.route_webhook(
+                 TestMessaging,
+                 "bridge_config_aware",
+                 %{"kind" => "noop"},
+                 headers: %{"authorization" => "bridge-secret"}
+               )
+
+      assert {:error, :invalid_signature} =
+               InboundRouter.route_webhook(
+                 TestMessaging,
+                 "bridge_config_aware",
+                 %{"kind" => "noop"},
+                 headers: %{"authorization" => "wrong-secret"}
+               )
+    end
+
     test "returns :noop for ack-only webhook events" do
       assert {:ok, :noop} =
                InboundRouter.route_webhook(

--- a/test/jido_messaging/outbound_gateway_test.exs
+++ b/test/jido_messaging/outbound_gateway_test.exs
@@ -87,6 +87,22 @@ defmodule Jido.Messaging.OutboundGatewayTest do
     def send_message(room_id, text, _opts), do: {:ok, %{message_id: "#{room_id}:#{text}"}}
   end
 
+  defmodule BridgeConfigChannel do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :bridge_config_channel
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(room_id, text, opts) do
+      send(opts[:test_pid], {:bridge_adapter_opts, opts})
+      {:ok, %{message_id: "#{room_id}:#{text}"}}
+    end
+  end
+
   defmodule MediaChannel do
     @behaviour Jido.Chat.Adapter
 
@@ -468,6 +484,60 @@ defmodule Jido.Messaging.OutboundGatewayTest do
     assert {:error, outbound_error} = OutboundGateway.send_message(TestMessaging, context, "always_fail")
     assert outbound_error.max_attempts == 1
     assert outbound_error.attempt == 1
+  end
+
+  test "passes selected bridge credentials and settings to the adapter" do
+    start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
+
+    {:ok, bridge_config} =
+      TestMessaging.put_bridge_config(%{
+        id: "config_bridge",
+        adapter_module: BridgeConfigChannel,
+        credentials: %{token: "bridge-token"},
+        opts: %{tenant: "tenant-one"}
+      })
+
+    context = %{
+      channel: BridgeConfigChannel,
+      bridge_id: "config_bridge",
+      external_room_id: "config_room"
+    }
+
+    assert {:ok, _result} =
+             OutboundGateway.send_message(TestMessaging, context, "hello", test_pid: self())
+
+    assert_receive {:bridge_adapter_opts, adapter_opts}
+    assert adapter_opts[:bridge_config] == bridge_config
+    assert adapter_opts[:credentials] == bridge_config.credentials
+    assert adapter_opts[:settings] == bridge_config.opts
+  end
+
+  test "call-specific adapter options override bridge defaults" do
+    start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
+
+    {:ok, _bridge_config} =
+      TestMessaging.put_bridge_config(%{
+        id: "override_bridge",
+        adapter_module: BridgeConfigChannel,
+        credentials: %{token: "stored-token"},
+        opts: %{tenant: "stored-tenant"}
+      })
+
+    context = %{
+      channel: BridgeConfigChannel,
+      bridge_id: "override_bridge",
+      external_room_id: "config_room"
+    }
+
+    assert {:ok, _result} =
+             OutboundGateway.send_message(TestMessaging, context, "hello",
+               test_pid: self(),
+               credentials: %{token: "override-token"}
+             )
+
+    assert_receive {:bridge_adapter_opts, adapter_opts}
+    assert adapter_opts[:credentials] == %{token: "override-token"}
+    assert adapter_opts[:settings] == %{tenant: "stored-tenant"}
   end
 
   defp start_messaging(opts) do

--- a/test/jido_messaging/outbound_gateway_test.exs
+++ b/test/jido_messaging/outbound_gateway_test.exs
@@ -486,58 +486,82 @@ defmodule Jido.Messaging.OutboundGatewayTest do
     assert outbound_error.attempt == 1
   end
 
-  test "passes selected bridge credentials and settings to the adapter" do
-    start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
+  describe "bridge adapter options" do
+    test "passes selected bridge credentials and settings to the adapter" do
+      start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
 
-    {:ok, bridge_config} =
-      TestMessaging.put_bridge_config(%{
-        id: "config_bridge",
-        adapter_module: BridgeConfigChannel,
-        credentials: %{token: "bridge-token"},
-        opts: %{tenant: "tenant-one"}
-      })
+      {:ok, bridge_config} =
+        TestMessaging.put_bridge_config(%{
+          id: "config_bridge",
+          adapter_module: BridgeConfigChannel,
+          credentials: %{token: "bridge-token"},
+          opts: %{tenant: "tenant-one"}
+        })
 
-    context = %{
-      channel: BridgeConfigChannel,
-      bridge_id: "config_bridge",
-      external_room_id: "config_room"
-    }
+      context = %{
+        channel: BridgeConfigChannel,
+        bridge_id: "config_bridge",
+        external_room_id: "config_room"
+      }
 
-    assert {:ok, _result} =
-             OutboundGateway.send_message(TestMessaging, context, "hello", test_pid: self())
+      assert {:ok, _result} =
+               OutboundGateway.send_message(TestMessaging, context, "hello", test_pid: self())
 
-    assert_receive {:bridge_adapter_opts, adapter_opts}
-    assert adapter_opts[:bridge_config] == bridge_config
-    assert adapter_opts[:credentials] == bridge_config.credentials
-    assert adapter_opts[:settings] == bridge_config.opts
-  end
+      assert_receive {:bridge_adapter_opts, adapter_opts}
+      assert adapter_opts[:bridge_config] == bridge_config
+      assert adapter_opts[:credentials] == bridge_config.credentials
+      assert adapter_opts[:settings] == bridge_config.opts
+    end
 
-  test "call-specific adapter options override bridge defaults" do
-    start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
+    test "call-specific adapter options override bridge defaults" do
+      start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
 
-    {:ok, _bridge_config} =
-      TestMessaging.put_bridge_config(%{
-        id: "override_bridge",
-        adapter_module: BridgeConfigChannel,
-        credentials: %{token: "stored-token"},
-        opts: %{tenant: "stored-tenant"}
-      })
+      {:ok, _bridge_config} =
+        TestMessaging.put_bridge_config(%{
+          id: "override_bridge",
+          adapter_module: BridgeConfigChannel,
+          credentials: %{token: "stored-token"},
+          opts: %{tenant: "stored-tenant"}
+        })
 
-    context = %{
-      channel: BridgeConfigChannel,
-      bridge_id: "override_bridge",
-      external_room_id: "config_room"
-    }
+      context = %{
+        channel: BridgeConfigChannel,
+        bridge_id: "override_bridge",
+        external_room_id: "config_room"
+      }
 
-    assert {:ok, _result} =
-             OutboundGateway.send_message(TestMessaging, context, "hello",
-               test_pid: self(),
-               credentials: %{token: "override-token"}
-             )
+      assert {:ok, _result} =
+               OutboundGateway.send_message(TestMessaging, context, "hello",
+                 test_pid: self(),
+                 credentials: %{token: "override-token"}
+               )
 
-    assert_receive {:bridge_adapter_opts, adapter_opts}
-    assert adapter_opts[:credentials] == %{token: "override-token"}
-    assert adapter_opts[:settings] == %{tenant: "stored-tenant"}
+      assert_receive {:bridge_adapter_opts, adapter_opts}
+      assert adapter_opts[:credentials] == %{token: "override-token"}
+      assert adapter_opts[:settings] == %{tenant: "stored-tenant"}
+    end
+
+    test "rejects a bridge config for a different adapter" do
+      start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
+
+      assert {:ok, _bridge_config} =
+               TestMessaging.put_bridge_config(%{
+                 id: "mismatch_bridge",
+                 adapter_module: BridgeConfigChannel,
+                 credentials: %{token: "must-not-leak"}
+               })
+
+      context = %{
+        channel: PartitionChannel,
+        bridge_id: "mismatch_bridge",
+        external_room_id: "config_room"
+      }
+
+      assert {:error, error} = OutboundGateway.send_message(TestMessaging, context, "hello")
+
+      assert error.reason ==
+               {:bridge_adapter_mismatch, "mismatch_bridge", BridgeConfigChannel, PartitionChannel}
+    end
   end
 
   defp start_messaging(opts) do


### PR DESCRIPTION
## Summary

- merge the selected bridge configuration into adapter call options
- give call-specific options documented precedence over stored defaults
- use bridge credentials and settings for inbound verification, parsing, and formatting
- resolve outbound credentials only during adapter execution so queue and dead-letter requests do not copy stored secrets

## Verification

- focused inbound, outbound, and Plug tests — 32 passed
- `mix test` — 539 passed, 4 skipped, 13 excluded

Closes #46