### PR TITLE
fix: restore persisted bridge workers on startup

### DIFF
--- a/lib/jido_messaging/bridge_supervisor.ex
+++ b/lib/jido_messaging/bridge_supervisor.ex
@@ -15,7 +15,12 @@ defmodule Jido.Messaging.BridgeSupervisor do
   """
   def start_link(opts) do
     name = Keyword.fetch!(opts, :name)
-    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
+    instance_module = Keyword.fetch!(opts, :instance_module)
+
+    with {:ok, supervisor} <- DynamicSupervisor.start_link(__MODULE__, opts, name: name),
+         :ok <- reconcile(instance_module) do
+      {:ok, supervisor}
+    end
   end
 
   @impl true

--- a/lib/jido_messaging/bridge_supervisor.ex
+++ b/lib/jido_messaging/bridge_supervisor.ex
@@ -17,9 +17,19 @@ defmodule Jido.Messaging.BridgeSupervisor do
     name = Keyword.fetch!(opts, :name)
     instance_module = Keyword.fetch!(opts, :instance_module)
 
-    with {:ok, supervisor} <- DynamicSupervisor.start_link(__MODULE__, opts, name: name),
-         :ok <- reconcile(instance_module) do
-      {:ok, supervisor}
+    case DynamicSupervisor.start_link(__MODULE__, opts, name: name) do
+      {:ok, supervisor} ->
+        case reconcile(instance_module) do
+          :ok ->
+            {:ok, supervisor}
+
+          {:error, _reason} = error ->
+            :ok = Supervisor.stop(supervisor)
+            error
+        end
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -39,27 +49,10 @@ defmodule Jido.Messaging.BridgeSupervisor do
 
     running = Map.new(list_running(instance_module), fn {bridge_id, pid} -> {bridge_id, pid} end)
 
-    running
-    |> Map.keys()
-    |> Enum.reject(&Map.has_key?(desired, &1))
-    |> Enum.each(&stop_bridge(instance_module, &1))
-
-    Enum.each(desired, fn {bridge_id, config} ->
-      case Map.get(running, bridge_id) do
-        nil ->
-          _ = start_bridge(instance_module, config)
-
-        pid ->
-          {:ok, %{revision: revision, adapter_module: adapter_module}} = BridgeServer.status(pid)
-
-          if revision != config.revision or adapter_module != config.adapter_module do
-            _ = stop_bridge(instance_module, bridge_id)
-            _ = start_bridge(instance_module, config)
-          end
-      end
-    end)
-
-    :ok
+    with :ok <- stop_removed_bridges(instance_module, desired, running),
+         :ok <- reconcile_desired_bridges(instance_module, desired, running) do
+      :ok
+    end
   end
 
   @spec start_bridge(module(), Jido.Messaging.BridgeConfig.t()) :: {:ok, pid()} | {:error, term()}
@@ -108,6 +101,48 @@ defmodule Jido.Messaging.BridgeSupervisor do
     registry = Module.concat(instance_module, Registry.Bridges)
 
     Registry.select(registry, [{{{:bridge, :"$1"}, :"$2", :"$3"}, [], [{{:"$1", :"$2"}}]}])
+  end
+
+  defp stop_removed_bridges(instance_module, desired, running) do
+    running
+    |> Map.keys()
+    |> Enum.reject(&Map.has_key?(desired, &1))
+    |> Enum.reduce_while(:ok, fn bridge_id, :ok ->
+      case stop_bridge(instance_module, bridge_id) do
+        :ok -> {:cont, :ok}
+        {:error, :not_found} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:stop_bridge_failed, bridge_id, reason}}}
+      end
+    end)
+  end
+
+  defp reconcile_desired_bridges(instance_module, desired, running) do
+    Enum.reduce_while(desired, :ok, fn {bridge_id, config}, :ok ->
+      case reconcile_bridge(instance_module, config, Map.get(running, bridge_id)) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:reconcile_bridge_failed, bridge_id, reason}}}
+      end
+    end)
+  end
+
+  defp reconcile_bridge(instance_module, config, nil) do
+    case start_bridge(instance_module, config) do
+      {:ok, _pid} -> :ok
+      {:error, reason} -> {:error, {:start_failed, reason}}
+    end
+  end
+
+  defp reconcile_bridge(instance_module, config, pid) do
+    with {:ok, status} <- BridgeServer.status(pid) do
+      if status.revision == config.revision and status.adapter_module == config.adapter_module do
+        :ok
+      else
+        with :ok <- stop_bridge(instance_module, config.id),
+             {:ok, _pid} <- start_bridge(instance_module, config) do
+          :ok
+        end
+      end
+    end
   end
 
   defp supervisor_name(instance_module), do: Module.concat(instance_module, BridgeSupervisor)

--- a/lib/jido_messaging/bridge_supervisor.ex
+++ b/lib/jido_messaging/bridge_supervisor.ex
@@ -111,7 +111,6 @@ defmodule Jido.Messaging.BridgeSupervisor do
       case stop_bridge(instance_module, bridge_id) do
         :ok -> {:cont, :ok}
         {:error, :not_found} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, {:stop_bridge_failed, bridge_id, reason}}}
       end
     end)
   end

--- a/lib/jido_messaging/supervisor.ex
+++ b/lib/jido_messaging/supervisor.ex
@@ -59,6 +59,11 @@ defmodule Jido.Messaging.Supervisor do
           {Registry, keys: :unique, name: instance_registry_name},
           {Registry, keys: :unique, name: bridge_registry_name},
           {Jido.Signal.Bus, name: signal_bus_name},
+          {Jido.Messaging.Runtime,
+           name: runtime_name,
+           instance_module: instance_module,
+           persistence: persistence,
+           persistence_opts: persistence_opts},
           {Jido.Messaging.RoomSupervisor, name: room_supervisor_name, instance_module: instance_module},
           {Jido.Messaging.AgentSupervisor, name: agent_supervisor_name, instance_module: instance_module},
           {Jido.Messaging.SessionManager.Supervisor,
@@ -71,12 +76,7 @@ defmodule Jido.Messaging.Supervisor do
           {Jido.Messaging.ConfigStore, name: config_store_name, instance_module: instance_module},
           {Jido.Messaging.InstanceSupervisor, name: instance_supervisor_name, instance_module: instance_module},
           {Jido.Messaging.BridgeSupervisor, name: bridge_supervisor_name, instance_module: instance_module},
-          {Jido.Messaging.Deduper, name: deduper_name, instance_module: instance_module},
-          {Jido.Messaging.Runtime,
-           name: runtime_name,
-           instance_module: instance_module,
-           persistence: persistence,
-           persistence_opts: persistence_opts}
+          {Jido.Messaging.Deduper, name: deduper_name, instance_module: instance_module}
         ]
 
         onboarding_children =

--- a/lib/jido_messaging/supervisor.ex
+++ b/lib/jido_messaging/supervisor.ex
@@ -74,9 +74,9 @@ defmodule Jido.Messaging.Supervisor do
           {Jido.Messaging.OutboundGateway.Supervisor,
            name: outbound_gateway_supervisor_name, instance_module: instance_module},
           {Jido.Messaging.ConfigStore, name: config_store_name, instance_module: instance_module},
+          {Jido.Messaging.Deduper, name: deduper_name, instance_module: instance_module},
           {Jido.Messaging.InstanceSupervisor, name: instance_supervisor_name, instance_module: instance_module},
-          {Jido.Messaging.BridgeSupervisor, name: bridge_supervisor_name, instance_module: instance_module},
-          {Jido.Messaging.Deduper, name: deduper_name, instance_module: instance_module}
+          {Jido.Messaging.BridgeSupervisor, name: bridge_supervisor_name, instance_module: instance_module}
         ]
 
         onboarding_children =

--- a/test/jido_messaging/bridge_startup_reconcile_test.exs
+++ b/test/jido_messaging/bridge_startup_reconcile_test.exs
@@ -1,0 +1,89 @@
+defmodule Jido.Messaging.BridgeStartupReconcileTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Messaging.BridgeServer
+
+  defmodule StartupAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :startup_reconcile
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, _text, _opts), do: {:ok, %{message_id: "sent"}}
+  end
+
+  defmodule SQLiteMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.SQLite
+  end
+
+  test "starts enabled bridge workers from persisted configuration" do
+    database_path = Path.join(System.tmp_dir!(), "jido_messaging_startup_#{System.unique_integer([:positive])}.db")
+    on_exit(fn -> File.rm(database_path) end)
+
+    {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+
+    assert {:ok, _bridge} =
+             SQLiteMessaging.put_bridge_config(%{
+               id: "persisted_bridge",
+               adapter_module: StartupAdapter,
+               enabled: true
+             })
+
+    assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
+
+    Supervisor.stop(first_supervisor)
+
+    {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+    on_exit(fn -> stop_supervisor(second_supervisor) end)
+
+    assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
+    assert {:ok, status} = SQLiteMessaging.bridge_status("persisted_bridge")
+    assert status.enabled
+  end
+
+  test "does not start disabled persisted bridges" do
+    database_path = Path.join(System.tmp_dir!(), "jido_messaging_disabled_#{System.unique_integer([:positive])}.db")
+    on_exit(fn -> File.rm(database_path) end)
+
+    {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+
+    assert {:ok, _bridge} =
+             SQLiteMessaging.put_bridge_config(%{
+               id: "disabled_bridge",
+               adapter_module: StartupAdapter,
+               enabled: false
+             })
+
+    Supervisor.stop(first_supervisor)
+    {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+    on_exit(fn -> stop_supervisor(second_supervisor) end)
+
+    refute BridgeServer.whereis(SQLiteMessaging, "disabled_bridge")
+    assert SQLiteMessaging.list_bridges() == []
+  end
+
+  defp assert_eventually(fun, attempts \\ 50)
+
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    if fun.() do
+      assert true
+    else
+      Process.sleep(10)
+      assert_eventually(fun, attempts - 1)
+    end
+  end
+
+  defp assert_eventually(_fun, 0), do: flunk("condition did not become true")
+
+  defp stop_supervisor(supervisor) do
+    if Process.alive?(supervisor) do
+      Supervisor.stop(supervisor)
+    end
+  catch
+    :exit, _reason -> :ok
+  end
+end

--- a/test/jido_messaging/bridge_startup_reconcile_test.exs
+++ b/test/jido_messaging/bridge_startup_reconcile_test.exs
@@ -1,7 +1,8 @@
 defmodule Jido.Messaging.BridgeStartupReconcileTest do
   use ExUnit.Case, async: false
 
-  alias Jido.Messaging.BridgeServer
+  alias Jido.Messaging.{BridgeConfig, BridgeServer}
+  alias Jido.Messaging.Persistence.SQLite
 
   defmodule StartupAdapter do
     @behaviour Jido.Chat.Adapter
@@ -16,54 +17,120 @@ defmodule Jido.Messaging.BridgeStartupReconcileTest do
     def send_message(_room_id, _text, _opts), do: {:ok, %{message_id: "sent"}}
   end
 
+  defmodule DependencyAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :startup_dependency
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, _text, _opts), do: {:ok, %{message_id: "sent"}}
+
+    @impl true
+    def listener_child_specs(_bridge_id, opts) do
+      deduper = Module.concat(Keyword.fetch!(opts, :instance_module), Deduper)
+
+      if Process.whereis(deduper) do
+        {:ok, []}
+      else
+        {:error, :deduper_unavailable}
+      end
+    end
+  end
+
+  defmodule FailingAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :startup_failure
+
+    @impl true
+    def transform_incoming(_payload), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, _text, _opts), do: {:ok, %{message_id: "sent"}}
+
+    @impl true
+    def listener_child_specs(_bridge_id, _opts), do: {:error, :listener_failed}
+  end
+
   defmodule SQLiteMessaging do
     use Jido.Messaging, persistence: Jido.Messaging.Persistence.SQLite
   end
 
-  test "starts enabled bridge workers from persisted configuration" do
-    database_path = Path.join(System.tmp_dir!(), "jido_messaging_startup_#{System.unique_integer([:positive])}.db")
-    on_exit(fn -> File.rm(database_path) end)
+  describe "startup reconciliation" do
+    test "starts enabled bridge workers from persisted configuration" do
+      database_path = tmp_path("startup")
+      on_exit(fn -> File.rm(database_path) end)
 
-    {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
 
-    assert {:ok, _bridge} =
-             SQLiteMessaging.put_bridge_config(%{
-               id: "persisted_bridge",
-               adapter_module: StartupAdapter,
-               enabled: true
-             })
+      assert {:ok, _bridge} =
+               SQLiteMessaging.put_bridge_config(%{
+                 id: "persisted_bridge",
+                 adapter_module: StartupAdapter,
+                 enabled: true
+               })
 
-    assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
+      assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
 
-    Supervisor.stop(first_supervisor)
+      Supervisor.stop(first_supervisor)
 
-    {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
-    on_exit(fn -> stop_supervisor(second_supervisor) end)
+      {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      on_exit(fn -> stop_supervisor(second_supervisor) end)
 
-    assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
-    assert {:ok, status} = SQLiteMessaging.bridge_status("persisted_bridge")
-    assert status.enabled
-  end
+      assert_eventually(fn -> is_pid(BridgeServer.whereis(SQLiteMessaging, "persisted_bridge")) end)
+      assert {:ok, status} = SQLiteMessaging.bridge_status("persisted_bridge")
+      assert status.enabled
+    end
 
-  test "does not start disabled persisted bridges" do
-    database_path = Path.join(System.tmp_dir!(), "jido_messaging_disabled_#{System.unique_integer([:positive])}.db")
-    on_exit(fn -> File.rm(database_path) end)
+    test "does not start disabled persisted bridges" do
+      database_path = tmp_path("disabled")
+      on_exit(fn -> File.rm(database_path) end)
 
-    {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      {:ok, first_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
 
-    assert {:ok, _bridge} =
-             SQLiteMessaging.put_bridge_config(%{
-               id: "disabled_bridge",
-               adapter_module: StartupAdapter,
-               enabled: false
-             })
+      assert {:ok, _bridge} =
+               SQLiteMessaging.put_bridge_config(%{
+                 id: "disabled_bridge",
+                 adapter_module: StartupAdapter,
+                 enabled: false
+               })
 
-    Supervisor.stop(first_supervisor)
-    {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
-    on_exit(fn -> stop_supervisor(second_supervisor) end)
+      Supervisor.stop(first_supervisor)
+      {:ok, second_supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      on_exit(fn -> stop_supervisor(second_supervisor) end)
 
-    refute BridgeServer.whereis(SQLiteMessaging, "disabled_bridge")
-    assert SQLiteMessaging.list_bridges() == []
+      refute BridgeServer.whereis(SQLiteMessaging, "disabled_bridge")
+      assert SQLiteMessaging.list_bridges() == []
+    end
+
+    test "starts bridge listeners only after the deduper is available" do
+      database_path = tmp_path("dependency_order")
+      on_exit(fn -> File.rm(database_path) end)
+      persist_bridge(database_path, "dependency_bridge", DependencyAdapter)
+
+      assert {:ok, supervisor} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      on_exit(fn -> stop_supervisor(supervisor) end)
+
+      assert is_pid(BridgeServer.whereis(SQLiteMessaging, "dependency_bridge"))
+    end
+
+    test "fails startup when a persisted enabled bridge cannot start" do
+      database_path = tmp_path("failed_bridge")
+      on_exit(fn -> File.rm(database_path) end)
+      persist_bridge(database_path, "failed_bridge", FailingAdapter)
+
+      previous_trap_exit = Process.flag(:trap_exit, true)
+      assert {:error, reason} = SQLiteMessaging.start_link(persistence_opts: [path: database_path])
+      Process.flag(:trap_exit, previous_trap_exit)
+
+      assert inspect(reason) =~ "listener_failed"
+      refute Process.whereis(Module.concat(SQLiteMessaging, :BridgeSupervisor))
+    end
   end
 
   defp assert_eventually(fun, attempts \\ 50)
@@ -85,5 +152,16 @@ defmodule Jido.Messaging.BridgeStartupReconcileTest do
     end
   catch
     :exit, _reason -> :ok
+  end
+
+  defp persist_bridge(database_path, bridge_id, adapter_module) do
+    {:ok, state} = SQLite.init(path: database_path)
+    config = BridgeConfig.new(%{id: bridge_id, adapter_module: adapter_module, enabled: true})
+    assert {:ok, ^config} = SQLite.save_bridge_config(state, config)
+    :ok = Exqlite.Sqlite3.close(state.db)
+  end
+
+  defp tmp_path(label) do
+    Path.join(System.tmp_dir!(), "jido_messaging_#{label}_#{System.unique_integer([:positive])}.db")
   end
 end


### PR DESCRIPTION
## Summary

- start persistence before the bridge control plane
- reconcile enabled bridge configurations when the bridge supervisor starts
- restore enabled SQLite-backed bridges after a runtime restart
- keep disabled persisted bridges stopped

## Verification

- restart and lifecycle tests — 9 passed
- `mix test` — 538 passed, 4 skipped, 13 excluded

Closes #49