### PR TITLE
fix: implement stable message cursor pagination

### DIFF
--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -181,7 +181,12 @@ defmodule Jido.Messaging do
         Jido.Messaging.get_message(__jido_messaging__(:runtime), message_id)
       end
 
-      @doc "List messages for a room"
+      @doc """
+      List messages for a room.
+
+      Use a message ID with `:before` or `:after` for cursor pagination. The
+      two cursor options are mutually exclusive.
+      """
       def list_messages(room_id, opts \\ []) do
         Jido.Messaging.list_messages(__jido_messaging__(:runtime), room_id, opts)
       end
@@ -790,7 +795,12 @@ defmodule Jido.Messaging do
     persistence.get_message(persistence_state, message_id)
   end
 
-  @doc "List messages for a room"
+  @doc """
+  List messages for a room.
+
+  Use a message ID with `:before` or `:after` for cursor pagination. The two
+  cursor options are mutually exclusive.
+  """
   def list_messages(runtime, room_id, opts \\ []) do
     {persistence, persistence_state} = Runtime.get_persistence(runtime)
     persistence.get_messages(persistence_state, room_id, opts)

--- a/lib/jido_messaging/persistence.ex
+++ b/lib/jido_messaging/persistence.ex
@@ -70,8 +70,16 @@ defmodule Jido.Messaging.Persistence do
   @doc "Get a message by ID"
   @callback get_message(state, message_id) :: {:ok, Message.t()} | {:error, :not_found}
 
-  @doc "Get messages for a room with options (limit, before, after)"
-  @callback get_messages(state, room_id, opts :: keyword()) :: {:ok, [Message.t()]}
+  @doc """
+  Get messages for a room with `:limit`, `:before`, and `:after` options.
+
+  Cursor values are message IDs. A cursor must identify a message in the same
+  room and optional thread scope. Adapters return `{:error, :cursor_not_found}`
+  for a missing or stale cursor and `{:error, :invalid_cursor_options}` when
+  both cursor directions are present.
+  """
+  @callback get_messages(state, room_id, opts :: keyword()) ::
+              {:ok, [Message.t()]} | {:error, :cursor_not_found | :invalid_cursor_options}
 
   @doc "Delete a message by ID"
   @callback delete_message(state, message_id) :: :ok | {:error, term()}

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -253,8 +253,11 @@ defmodule Jido.Messaging.Persistence.ETS do
   end
 
   defp message_order_key(message) do
-    {DateTime.to_unix(message.inserted_at, :microsecond), message.id}
+    {message_timestamp_key(message.inserted_at), message.id}
   end
+
+  defp message_timestamp_key(%DateTime{} = inserted_at), do: DateTime.to_iso8601(inserted_at)
+  defp message_timestamp_key(nil), do: ""
 
   @impl true
   def delete_message(state, message_id) do

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -208,12 +208,52 @@ defmodule Jido.Messaging.Persistence.ETS do
           [] -> []
         end
       end)
-      |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
       |> maybe_filter_thread(thread_id)
-      |> Enum.take(limit)
-      |> Enum.reverse()
+      |> Enum.sort_by(&message_order_key/1)
 
-    {:ok, messages}
+    paginate_messages(messages, opts, limit)
+  end
+
+  defp paginate_messages(messages, opts, limit) do
+    case cursor_direction(opts) do
+      :none ->
+        {:ok, Enum.take(messages, -limit)}
+
+      {:before, cursor_id} ->
+        with {:ok, cursor} <- find_cursor(messages, cursor_id) do
+          page = messages |> Enum.filter(&(message_order_key(&1) < message_order_key(cursor))) |> Enum.take(-limit)
+          {:ok, page}
+        end
+
+      {:after, cursor_id} ->
+        with {:ok, cursor} <- find_cursor(messages, cursor_id) do
+          page = messages |> Enum.filter(&(message_order_key(&1) > message_order_key(cursor))) |> Enum.take(limit)
+          {:ok, page}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp cursor_direction(opts) do
+    case {Keyword.get(opts, :before), Keyword.get(opts, :after)} do
+      {nil, nil} -> :none
+      {before, nil} when is_binary(before) and before != "" -> {:before, before}
+      {nil, after_cursor} when is_binary(after_cursor) and after_cursor != "" -> {:after, after_cursor}
+      {_before, _after_cursor} -> {:error, :invalid_cursor_options}
+    end
+  end
+
+  defp find_cursor(messages, cursor_id) do
+    case Enum.find(messages, &(&1.id == cursor_id)) do
+      nil -> {:error, :cursor_not_found}
+      cursor -> {:ok, cursor}
+    end
+  end
+
+  defp message_order_key(message) do
+    {DateTime.to_unix(message.inserted_at, :microsecond), message.id}
   end
 
   @impl true

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -148,7 +148,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
     with {:ok, rows} <-
            query_all(
              state.db,
-             "SELECT inserted_at, id FROM #{@table} WHERE #{where} AND id = ?#{cursor_param} LIMIT 1",
+             "SELECT COALESCE(inserted_at, ''), id FROM #{@table} WHERE #{where} AND id = ?#{cursor_param} LIMIT 1",
              params ++ [cursor_id]
            ) do
       case rows do
@@ -166,8 +166,8 @@ defmodule Jido.Messaging.Persistence.SQLite do
     id_param = timestamp_param + 1
 
     cursor_where =
-      "#{where} AND (inserted_at #{operator} ?#{timestamp_param} OR " <>
-        "(inserted_at = ?#{timestamp_param} AND id #{operator} ?#{id_param}))"
+      "#{where} AND (COALESCE(inserted_at, '') #{operator} ?#{timestamp_param} OR " <>
+        "(COALESCE(inserted_at, '') = ?#{timestamp_param} AND id #{operator} ?#{id_param}))"
 
     order = if direction == :before, do: "DESC", else: "ASC"
     {cursor_where, params ++ [inserted_at, id], order, direction == :before}
@@ -180,7 +180,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
       SELECT payload
       FROM #{@table}
       WHERE #{where}
-      ORDER BY inserted_at #{order}, id #{order}
+      ORDER BY COALESCE(inserted_at, '') #{order}, id #{order}
       LIMIT ?#{length(params) + 1}
       """,
       params ++ [limit]

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -115,27 +115,76 @@ defmodule Jido.Messaging.Persistence.SQLite do
     limit = Keyword.get(opts, :limit, 50)
     thread_id = Keyword.get(opts, :thread_id)
 
-    {where, params} =
-      if is_binary(thread_id) do
-        {"kind = ?1 AND room_id = ?2 AND thread_id = ?3", ["message", room_id, thread_id]}
-      else
-        {"kind = ?1 AND room_id = ?2", ["message", room_id]}
-      end
+    with {:ok, direction} <- cursor_direction(opts),
+         {where, params} <- message_scope(room_id, thread_id),
+         {:ok, cursor} <- resolve_message_cursor(state, where, params, direction),
+         {where, params, order, reverse?} <- apply_message_cursor(where, params, direction, cursor),
+         {:ok, rows} <- query_message_page(state, where, params, order, limit) do
+      messages = decode_rows(rows)
+      {:ok, if(reverse?, do: Enum.reverse(messages), else: messages)}
+    end
+  end
+
+  defp cursor_direction(opts) do
+    case {Keyword.get(opts, :before), Keyword.get(opts, :after)} do
+      {nil, nil} -> {:ok, :none}
+      {before, nil} when is_binary(before) and before != "" -> {:ok, {:before, before}}
+      {nil, after_cursor} when is_binary(after_cursor) and after_cursor != "" -> {:ok, {:after, after_cursor}}
+      {_before, _after_cursor} -> {:error, :invalid_cursor_options}
+    end
+  end
+
+  defp message_scope(room_id, thread_id) when is_binary(thread_id) do
+    {"kind = ?1 AND room_id = ?2 AND thread_id = ?3", ["message", room_id, thread_id]}
+  end
+
+  defp message_scope(room_id, _thread_id), do: {"kind = ?1 AND room_id = ?2", ["message", room_id]}
+
+  defp resolve_message_cursor(_state, _where, _params, :none), do: {:ok, nil}
+
+  defp resolve_message_cursor(state, where, params, {_direction, cursor_id}) do
+    cursor_param = length(params) + 1
 
     with {:ok, rows} <-
            query_all(
              state.db,
-             """
-             SELECT payload
-             FROM #{@table}
-             WHERE #{where}
-             ORDER BY inserted_at DESC, id DESC
-             LIMIT ?#{length(params) + 1}
-             """,
-             params ++ [limit]
+             "SELECT inserted_at, id FROM #{@table} WHERE #{where} AND id = ?#{cursor_param} LIMIT 1",
+             params ++ [cursor_id]
            ) do
-      {:ok, rows |> decode_rows() |> Enum.reverse()}
+      case rows do
+        [[inserted_at, id]] -> {:ok, {inserted_at, id}}
+        [] -> {:error, :cursor_not_found}
+      end
     end
+  end
+
+  defp apply_message_cursor(where, params, :none, nil), do: {where, params, "DESC", true}
+
+  defp apply_message_cursor(where, params, {direction, _cursor_id}, {inserted_at, id}) do
+    operator = if direction == :before, do: "<", else: ">"
+    timestamp_param = length(params) + 1
+    id_param = timestamp_param + 1
+
+    cursor_where =
+      "#{where} AND (inserted_at #{operator} ?#{timestamp_param} OR " <>
+        "(inserted_at = ?#{timestamp_param} AND id #{operator} ?#{id_param}))"
+
+    order = if direction == :before, do: "DESC", else: "ASC"
+    {cursor_where, params ++ [inserted_at, id], order, direction == :before}
+  end
+
+  defp query_message_page(state, where, params, order, limit) do
+    query_all(
+      state.db,
+      """
+      SELECT payload
+      FROM #{@table}
+      WHERE #{where}
+      ORDER BY inserted_at #{order}, id #{order}
+      LIMIT ?#{length(params) + 1}
+      """,
+      params ++ [limit]
+    )
   end
 
   @impl true

--- a/test/jido_messaging/persistence/ets_test.exs
+++ b/test/jido_messaging/persistence/ets_test.exs
@@ -116,6 +116,26 @@ defmodule Jido.Messaging.Persistence.ETSTest do
       assert Enum.map(thread_messages, & &1.id) == [root.id, reply.id]
     end
 
+    test "get_messages/3 paginates before and after a stable message cursor", %{state: state} do
+      room = persist_room!(state)
+      messages = pagination_messages(room.id)
+      Enum.each(messages, &ETS.save_message(state, &1))
+
+      assert {:ok, latest} = ETS.get_messages(state, room.id, limit: 2)
+      assert Enum.map(latest, & &1.id) == ["message:3", "message:4"]
+
+      assert {:ok, older} = ETS.get_messages(state, room.id, before: "message:3", limit: 2)
+      assert Enum.map(older, & &1.id) == ["message:1", "message:2"]
+
+      assert {:ok, newer} = ETS.get_messages(state, room.id, after: "message:2", limit: 2)
+      assert Enum.map(newer, & &1.id) == ["message:3", "message:4"]
+
+      assert {:error, :cursor_not_found} = ETS.get_messages(state, room.id, before: "missing")
+
+      assert {:error, :invalid_cursor_options} =
+               ETS.get_messages(state, room.id, before: "message:3", after: "message:2")
+    end
+
     test "delete_message/2 removes the room and thread indexes", %{state: state} do
       room = persist_room!(state)
       thread = persist_thread!(state, %{room_id: room.id, external_thread_id: "thread-1"})
@@ -190,5 +210,27 @@ defmodule Jido.Messaging.Persistence.ETSTest do
     thread = Thread.new(attrs)
     {:ok, thread} = ETS.save_thread(state, thread)
     thread
+  end
+
+  defp pagination_messages(room_id) do
+    base = ~U[2026-01-01 00:00:00.000000Z]
+
+    [
+      pagination_message("message:1", room_id, base),
+      pagination_message("message:2", room_id, DateTime.add(base, 1, :second)),
+      pagination_message("message:3", room_id, DateTime.add(base, 1, :second)),
+      pagination_message("message:4", room_id, DateTime.add(base, 2, :second))
+    ]
+  end
+
+  defp pagination_message(id, room_id, inserted_at) do
+    Message.new(%{
+      id: id,
+      room_id: room_id,
+      sender_id: "user:cursor",
+      role: :user,
+      content: [%{type: :text, text: id}],
+      inserted_at: inserted_at
+    })
   end
 end

--- a/test/jido_messaging/persistence/ets_test.exs
+++ b/test/jido_messaging/persistence/ets_test.exs
@@ -136,6 +136,47 @@ defmodule Jido.Messaging.Persistence.ETSTest do
                ETS.get_messages(state, room.id, before: "message:3", after: "message:2")
     end
 
+    test "get_messages/3 traverses boundaries without repeats and rejects stale or out-of-scope cursors", %{
+      state: state
+    } do
+      room = persist_room!(state)
+      messages = pagination_messages(room.id)
+      Enum.each(messages, &ETS.save_message(state, &1))
+
+      assert {:ok, first_page} = ETS.get_messages(state, room.id, limit: 2)
+      assert {:ok, second_page} = ETS.get_messages(state, room.id, before: hd(first_page).id, limit: 2)
+      assert Enum.map(second_page ++ first_page, & &1.id) == Enum.map(messages, & &1.id)
+
+      assert {:ok, []} = ETS.get_messages(state, room.id, before: hd(messages).id, limit: 2)
+      assert {:ok, []} = ETS.get_messages(state, room.id, after: List.last(messages).id, limit: 2)
+
+      assert :ok = ETS.delete_message(state, "message:2")
+      assert {:error, :cursor_not_found} = ETS.get_messages(state, room.id, after: "message:2")
+
+      thread_cursor = pagination_message("message:thread-cursor", room.id, hd(messages).inserted_at, "thread:one")
+      thread_message = pagination_message("message:thread", room.id, List.last(messages).inserted_at, "thread:one")
+      assert {:ok, _message} = ETS.save_message(state, thread_cursor)
+      assert {:ok, _message} = ETS.save_message(state, thread_message)
+
+      assert {:ok, [^thread_message]} =
+               ETS.get_messages(state, room.id, thread_id: "thread:one", after: thread_cursor.id)
+
+      assert {:error, :cursor_not_found} =
+               ETS.get_messages(state, room.id, thread_id: "thread:other", after: thread_cursor.id)
+    end
+
+    test "get_messages/3 gives deterministic order to imported messages without timestamps", %{state: state} do
+      room = persist_room!(state)
+      missing_timestamp = pagination_message("message:missing-time", room.id, nil)
+      timestamped = pagination_message("message:timestamped", room.id, ~U[2026-01-01 00:00:00Z])
+
+      assert {:ok, _message} = ETS.save_message(state, timestamped)
+      assert {:ok, _message} = ETS.save_message(state, missing_timestamp)
+
+      assert {:ok, [^missing_timestamp, ^timestamped]} = ETS.get_messages(state, room.id)
+      assert {:ok, [^timestamped]} = ETS.get_messages(state, room.id, after: missing_timestamp.id)
+    end
+
     test "delete_message/2 removes the room and thread indexes", %{state: state} do
       room = persist_room!(state)
       thread = persist_thread!(state, %{room_id: room.id, external_thread_id: "thread-1"})
@@ -223,14 +264,15 @@ defmodule Jido.Messaging.Persistence.ETSTest do
     ]
   end
 
-  defp pagination_message(id, room_id, inserted_at) do
+  defp pagination_message(id, room_id, inserted_at, thread_id \\ nil) do
     Message.new(%{
       id: id,
       room_id: room_id,
       sender_id: "user:cursor",
       role: :user,
       content: [%{type: :text, text: id}],
-      inserted_at: inserted_at
+      inserted_at: inserted_at,
+      thread_id: thread_id
     })
   end
 end

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -163,6 +163,32 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :ok = Sqlite3.close(state.db)
   end
 
+  test "paginates before and after a stable message cursor" do
+    path = tmp_path("sqlite-cursors")
+    {:ok, state} = SQLite.init(path: path)
+    room = Room.new(%{id: "room:cursors", type: :channel, name: "cursors"})
+    assert {:ok, ^room} = SQLite.save_room(state, room)
+
+    messages = pagination_messages(room.id)
+    Enum.each(messages, &SQLite.save_message(state, &1))
+
+    assert {:ok, latest} = SQLite.get_messages(state, room.id, limit: 2)
+    assert Enum.map(latest, & &1.id) == ["message:3", "message:4"]
+
+    assert {:ok, older} = SQLite.get_messages(state, room.id, before: "message:3", limit: 2)
+    assert Enum.map(older, & &1.id) == ["message:1", "message:2"]
+
+    assert {:ok, newer} = SQLite.get_messages(state, room.id, after: "message:2", limit: 2)
+    assert Enum.map(newer, & &1.id) == ["message:3", "message:4"]
+
+    assert {:error, :cursor_not_found} = SQLite.get_messages(state, room.id, after: "missing")
+
+    assert {:error, :invalid_cursor_options} =
+             SQLite.get_messages(state, room.id, before: "message:3", after: "message:2")
+
+    :ok = Sqlite3.close(state.db)
+  end
+
   test "room_timeline returns raw timeline messages and thread replies" do
     path = tmp_path("sqlite-query")
     start_supervised!({SQLiteMessaging, persistence_opts: [path: path]})
@@ -202,5 +228,27 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     path = Path.join(["tmp", "#{prefix}-#{System.unique_integer([:positive])}.sqlite3"])
     File.rm(path)
     path
+  end
+
+  defp pagination_messages(room_id) do
+    base = ~U[2026-01-01 00:00:00.000000Z]
+
+    [
+      pagination_message("message:1", room_id, base),
+      pagination_message("message:2", room_id, DateTime.add(base, 1, :second)),
+      pagination_message("message:3", room_id, DateTime.add(base, 1, :second)),
+      pagination_message("message:4", room_id, DateTime.add(base, 2, :second))
+    ]
+  end
+
+  defp pagination_message(id, room_id, inserted_at) do
+    Message.new(%{
+      id: id,
+      room_id: room_id,
+      sender_id: "user:cursor",
+      role: :user,
+      content: [%{type: :text, text: id}],
+      inserted_at: inserted_at
+    })
   end
 end

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -189,6 +189,56 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :ok = Sqlite3.close(state.db)
   end
 
+  test "traverses cursor boundaries and rejects stale or out-of-scope cursors" do
+    path = tmp_path("sqlite-cursor-boundaries")
+    {:ok, state} = SQLite.init(path: path)
+    room = Room.new(%{id: "room:cursor-boundaries", type: :channel, name: "cursor-boundaries"})
+    assert {:ok, ^room} = SQLite.save_room(state, room)
+
+    messages = pagination_messages(room.id)
+    Enum.each(messages, &SQLite.save_message(state, &1))
+
+    assert {:ok, first_page} = SQLite.get_messages(state, room.id, limit: 2)
+    assert {:ok, second_page} = SQLite.get_messages(state, room.id, before: hd(first_page).id, limit: 2)
+    assert Enum.map(second_page ++ first_page, & &1.id) == Enum.map(messages, & &1.id)
+
+    assert {:ok, []} = SQLite.get_messages(state, room.id, before: hd(messages).id, limit: 2)
+    assert {:ok, []} = SQLite.get_messages(state, room.id, after: List.last(messages).id, limit: 2)
+
+    assert :ok = SQLite.delete_message(state, "message:2")
+    assert {:error, :cursor_not_found} = SQLite.get_messages(state, room.id, after: "message:2")
+
+    thread_cursor = pagination_message("message:thread-cursor", room.id, hd(messages).inserted_at, "thread:one")
+    thread_message = pagination_message("message:thread", room.id, List.last(messages).inserted_at, "thread:one")
+    assert {:ok, _message} = SQLite.save_message(state, thread_cursor)
+    assert {:ok, _message} = SQLite.save_message(state, thread_message)
+
+    assert {:ok, [^thread_message]} =
+             SQLite.get_messages(state, room.id, thread_id: "thread:one", after: thread_cursor.id)
+
+    assert {:error, :cursor_not_found} =
+             SQLite.get_messages(state, room.id, thread_id: "thread:other", after: thread_cursor.id)
+
+    :ok = Sqlite3.close(state.db)
+  end
+
+  test "orders imported messages without timestamps consistently with ETS" do
+    path = tmp_path("sqlite-cursor-null-time")
+    {:ok, state} = SQLite.init(path: path)
+    room = Room.new(%{id: "room:cursor-null-time", type: :channel, name: "cursor-null-time"})
+    assert {:ok, ^room} = SQLite.save_room(state, room)
+
+    missing_timestamp = pagination_message("message:missing-time", room.id, nil)
+    timestamped = pagination_message("message:timestamped", room.id, ~U[2026-01-01 00:00:00Z])
+    assert {:ok, _message} = SQLite.save_message(state, timestamped)
+    assert {:ok, _message} = SQLite.save_message(state, missing_timestamp)
+
+    assert {:ok, [^missing_timestamp, ^timestamped]} = SQLite.get_messages(state, room.id)
+    assert {:ok, [^timestamped]} = SQLite.get_messages(state, room.id, after: missing_timestamp.id)
+
+    :ok = Sqlite3.close(state.db)
+  end
+
   test "room_timeline returns raw timeline messages and thread replies" do
     path = tmp_path("sqlite-query")
     start_supervised!({SQLiteMessaging, persistence_opts: [path: path]})
@@ -241,14 +291,15 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     ]
   end
 
-  defp pagination_message(id, room_id, inserted_at) do
+  defp pagination_message(id, room_id, inserted_at, thread_id \\ nil) do
     Message.new(%{
       id: id,
       room_id: room_id,
       sender_id: "user:cursor",
       role: :user,
       content: [%{type: :text, text: id}],
-      inserted_at: inserted_at
+      inserted_at: inserted_at,
+      thread_id: thread_id
     })
   end
 end


### PR DESCRIPTION
## Summary

- define message IDs as `before` and `after` cursors
- order pages by stable `(inserted_at, id)` keys
- implement equivalent cursor behavior in ETS and SQLite
- return explicit errors for stale cursors and conflicting cursor options
- document the public pagination contract

## Verification

- ETS and SQLite persistence tests — 17 passed
- `mix test` — 538 passed, 4 skipped, 13 excluded

Closes #54