### PR TITLE
fix: isolate messaging instances in SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ bridge bindings, routing policies, bridge configs, and ingress subscriptions.
 `room_timeline/2` returns top-level messages, grouped thread replies, and reply
 counts from the persisted message records.
 
+Each `Jido.Messaging` runtime uses its module name as a SQLite instance
+namespace. Different runtimes can therefore share one database path without
+reading or replacing each other's records. Set `persistence_opts: [instance_id:
+"stable-name"]` when a namespace must remain stable across a module rename.
+Direct calls to `Jido.Messaging.Persistence.SQLite.init/1` use the explicit
+default namespace `"default"` unless `:instance_id` is supplied.
+
 ### Presence Signals
 
 `Jido.Messaging.Presence` bridges transport-specific presence state, such as

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -49,7 +49,9 @@ defmodule Jido.Messaging.Persistence.SQLite do
     :ok = ensure_parent_dir(path)
 
     with {:ok, db} <- Sqlite3.open(path) do
-      case migrate(db, instance_id) do
+      :ok = Sqlite3.set_busy_timeout(db, 5_000)
+
+      case with_migration_lock(path, fn -> migrate(db, instance_id) end) do
         :ok ->
           {:ok, %__MODULE__{db: db, path: path, instance_id: instance_id}}
 
@@ -498,10 +500,39 @@ defmodule Jido.Messaging.Persistence.SQLite do
     end
   end
 
+  defp with_migration_lock(path, fun) do
+    resource = {__MODULE__, Path.expand(path), :schema_migration}
+
+    case :global.trans({resource, self()}, fun) do
+      :aborted -> {:error, :migration_lock_aborted}
+      result -> result
+    end
+  end
+
   defp migrate_legacy_table(db, instance_id) do
     result =
       with :ok <- exec(db, "BEGIN IMMEDIATE"),
-           :ok <- exec(db, "ALTER TABLE #{@table} RENAME TO #{@table}_legacy"),
+           {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []),
+           :ok <- migrate_legacy_table_locked(db, columns, instance_id),
+           :ok <- exec(db, "COMMIT") do
+        :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, _reason} = error ->
+        _ = exec(db, "ROLLBACK")
+        error
+    end
+  end
+
+  defp migrate_legacy_table_locked(db, columns, instance_id) do
+    if Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) do
+      create_indexes(db)
+    else
+      with :ok <- exec(db, "ALTER TABLE #{@table} RENAME TO #{@table}_legacy"),
            :ok <- exec(db, create_table_sql()),
            :ok <-
              run(
@@ -514,19 +545,9 @@ defmodule Jido.Messaging.Persistence.SQLite do
                """,
                [instance_id]
              ),
-           :ok <- exec(db, "DROP TABLE #{@table}_legacy"),
-           :ok <- create_indexes(db),
-           :ok <- exec(db, "COMMIT") do
-        :ok
+           :ok <- exec(db, "DROP TABLE #{@table}_legacy") do
+        create_indexes(db)
       end
-
-    case result do
-      :ok ->
-        :ok
-
-      {:error, _reason} = error ->
-        _ = exec(db, "ROLLBACK")
-        error
     end
   end
 

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -10,6 +10,9 @@ defmodule Jido.Messaging.Persistence.SQLite do
   ## Options
 
     * `:path` - SQLite database path. Defaults to `"data/jido_messaging.sqlite3"`.
+    * `:instance_id` - stable namespace for all records. Direct adapter use
+      defaults to `"default"`. A `Jido.Messaging` runtime supplies its module
+      name when this option is absent.
 
   """
 
@@ -29,23 +32,26 @@ defmodule Jido.Messaging.Persistence.SQLite do
   }
 
   @table "jido_messaging_records"
+  @default_instance_id "default"
 
-  defstruct [:db, :path]
+  defstruct [:db, :path, :instance_id]
 
   @type t :: %__MODULE__{
           db: reference(),
-          path: String.t()
+          path: String.t(),
+          instance_id: String.t()
         }
 
   @impl true
   def init(opts) do
     path = opts |> Keyword.get(:path, "data/jido_messaging.sqlite3") |> to_string()
+    instance_id = opts |> Keyword.get(:instance_id, @default_instance_id) |> normalize_instance_id()
     :ok = ensure_parent_dir(path)
 
     with {:ok, db} <- Sqlite3.open(path) do
-      case migrate(db) do
+      case migrate(db, instance_id) do
         :ok ->
-          {:ok, %__MODULE__{db: db, path: path}}
+          {:ok, %__MODULE__{db: db, path: path, instance_id: instance_id}}
 
         {:error, _reason} = error ->
           _ = Sqlite3.close(db)
@@ -68,10 +74,11 @@ defmodule Jido.Messaging.Persistence.SQLite do
       state.db,
       """
       DELETE FROM #{@table}
-      WHERE (kind = 'room' AND id = ?1)
-         OR (kind IN ('message', 'thread', 'room_binding', 'routing_policy') AND room_id = ?1)
+      WHERE instance_id = ?1
+        AND ((kind = 'room' AND id = ?2)
+         OR (kind IN ('message', 'thread', 'room_binding', 'routing_policy') AND room_id = ?2))
       """,
-      [room_id]
+      [state.instance_id, room_id]
     )
   end
 
@@ -116,7 +123,8 @@ defmodule Jido.Messaging.Persistence.SQLite do
     thread_id = Keyword.get(opts, :thread_id)
 
     with {:ok, direction} <- cursor_direction(opts),
-         {where, params} <- message_scope(room_id, thread_id),
+         {scope_where, scope_params} <- message_scope(room_id, thread_id),
+         {where, params} <- with_instance_scope(state, scope_where, scope_params),
          {:ok, cursor} <- resolve_message_cursor(state, where, params, direction),
          {where, params, order, reverse?} <- apply_message_cursor(where, params, direction, cursor),
          {:ok, rows} <- query_message_page(state, where, params, order, limit) do
@@ -470,12 +478,63 @@ defmodule Jido.Messaging.Persistence.SQLite do
     |> File.mkdir_p()
   end
 
-  defp migrate(db) do
-    exec(db, """
-    PRAGMA journal_mode = WAL;
-    PRAGMA synchronous = NORMAL;
+  defp migrate(db, instance_id) do
+    with :ok <-
+           exec(db, """
+           PRAGMA journal_mode = WAL;
+           PRAGMA synchronous = NORMAL;
+           """),
+         {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []) do
+      cond do
+        columns == [] ->
+          with :ok <- exec(db, create_table_sql()), do: create_indexes(db)
+
+        Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) ->
+          create_indexes(db)
+
+        true ->
+          migrate_legacy_table(db, instance_id)
+      end
+    end
+  end
+
+  defp migrate_legacy_table(db, instance_id) do
+    result =
+      with :ok <- exec(db, "BEGIN IMMEDIATE"),
+           :ok <- exec(db, "ALTER TABLE #{@table} RENAME TO #{@table}_legacy"),
+           :ok <- exec(db, create_table_sql()),
+           :ok <-
+             run(
+               db,
+               """
+               INSERT INTO #{@table}
+                 (instance_id, kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
+               SELECT ?1, kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload
+               FROM #{@table}_legacy
+               """,
+               [instance_id]
+             ),
+           :ok <- exec(db, "DROP TABLE #{@table}_legacy"),
+           :ok <- create_indexes(db),
+           :ok <- exec(db, "COMMIT") do
+        :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, _reason} = error ->
+        _ = exec(db, "ROLLBACK")
+        error
+    end
+  end
+
+  defp create_table_sql do
+    """
 
     CREATE TABLE IF NOT EXISTS #{@table} (
+      instance_id TEXT NOT NULL,
       kind TEXT NOT NULL,
       id TEXT NOT NULL,
       room_id TEXT,
@@ -485,17 +544,21 @@ defmodule Jido.Messaging.Persistence.SQLite do
       bridge_id TEXT,
       external_id TEXT,
       payload BLOB NOT NULL,
-      PRIMARY KEY (kind, id)
+      PRIMARY KEY (instance_id, kind, id)
     );
+    """
+  end
 
+  defp create_indexes(db) do
+    exec(db, """
     CREATE INDEX IF NOT EXISTS #{@table}_room_idx
-      ON #{@table} (kind, room_id);
+      ON #{@table} (instance_id, kind, room_id);
 
     CREATE INDEX IF NOT EXISTS #{@table}_thread_idx
-      ON #{@table} (kind, thread_id);
+      ON #{@table} (instance_id, kind, thread_id);
 
     CREATE INDEX IF NOT EXISTS #{@table}_external_idx
-      ON #{@table} (kind, channel, bridge_id, external_id);
+      ON #{@table} (instance_id, kind, channel, bridge_id, external_id);
     """)
   end
 
@@ -510,9 +573,9 @@ defmodule Jido.Messaging.Persistence.SQLite do
       state.db,
       """
       INSERT INTO #{@table}
-        (kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
-      ON CONFLICT(kind, id) DO UPDATE SET
+        (instance_id, kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+      ON CONFLICT(instance_id, kind, id) DO UPDATE SET
         room_id = excluded.room_id,
         thread_id = excluded.thread_id,
         inserted_at = excluded.inserted_at,
@@ -522,6 +585,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
         payload = excluded.payload
       """,
       [
+        state.instance_id,
         kind,
         id,
         Keyword.get(opts, :room_id),
@@ -540,7 +604,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
   end
 
   defp fetch_one(state, kind, filters) do
-    {where, params} = where_clause([{"kind", kind} | filters])
+    {where, params} = where_clause([{"instance_id", state.instance_id}, {"kind", kind} | filters])
 
     with {:ok, rows} <-
            query_all(
@@ -567,6 +631,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
   defp query_records(state, where, params, opts) do
     limit = Keyword.fetch!(opts, :limit)
     order = Keyword.get(opts, :order, "inserted_at ASC, id ASC")
+    {where, params} = with_instance_scope(state, where, params)
 
     with {:ok, rows} <-
            query_all(
@@ -585,7 +650,16 @@ defmodule Jido.Messaging.Persistence.SQLite do
   end
 
   defp delete_record(state, kind, id) do
-    run(state.db, "DELETE FROM #{@table} WHERE kind = ?1 AND id = ?2", [kind, id])
+    run(
+      state.db,
+      "DELETE FROM #{@table} WHERE instance_id = ?1 AND kind = ?2 AND id = ?3",
+      [state.instance_id, kind, id]
+    )
+  end
+
+  defp with_instance_scope(state, where, params) do
+    instance_param = length(params) + 1
+    {"(#{where}) AND instance_id = ?#{instance_param}", params ++ [state.instance_id]}
   end
 
   defp find_record({:ok, records}, predicate) do
@@ -803,4 +877,11 @@ defmodule Jido.Messaging.Persistence.SQLite do
   defp normalize_term(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_term(value) when is_integer(value), do: Integer.to_string(value)
   defp normalize_term(value), do: inspect(value)
+
+  defp normalize_instance_id(value) do
+    case value |> to_string() |> String.trim() do
+      "" -> @default_instance_id
+      instance_id -> instance_id
+    end
+  end
 end

--- a/lib/jido_messaging/runtime.ex
+++ b/lib/jido_messaging/runtime.ex
@@ -44,7 +44,11 @@ defmodule Jido.Messaging.Runtime do
   def init(opts) do
     instance_module = Keyword.fetch!(opts, :instance_module)
     persistence = Keyword.fetch!(opts, :persistence)
-    persistence_opts = Keyword.get(opts, :persistence_opts, [])
+
+    persistence_opts =
+      opts
+      |> Keyword.get(:persistence_opts, [])
+      |> Keyword.put_new(:instance_id, Atom.to_string(instance_module))
 
     case persistence.init(persistence_opts) do
       {:ok, persistence_state} ->

--- a/lib/jido_messaging/runtime.ex
+++ b/lib/jido_messaging/runtime.ex
@@ -48,7 +48,7 @@ defmodule Jido.Messaging.Runtime do
     persistence_opts =
       opts
       |> Keyword.get(:persistence_opts, [])
-      |> Keyword.put_new(:instance_id, Atom.to_string(instance_module))
+      |> maybe_add_instance_scope(persistence, instance_module)
 
     case persistence.init(persistence_opts) do
       {:ok, persistence_state} ->
@@ -75,4 +75,10 @@ defmodule Jido.Messaging.Runtime do
   def handle_call(:get_persistence, _from, state) do
     {:reply, {state.persistence, state.persistence_state}, state}
   end
+
+  defp maybe_add_instance_scope(opts, Jido.Messaging.Persistence.SQLite, instance_module) do
+    Keyword.put_new(opts, :instance_id, Atom.to_string(instance_module))
+  end
+
+  defp maybe_add_instance_scope(opts, _persistence, _instance_module), do: opts
 end

--- a/test/jido_messaging/bridge_startup_reconcile_test.exs
+++ b/test/jido_messaging/bridge_startup_reconcile_test.exs
@@ -155,7 +155,12 @@ defmodule Jido.Messaging.BridgeStartupReconcileTest do
   end
 
   defp persist_bridge(database_path, bridge_id, adapter_module) do
-    {:ok, state} = SQLite.init(path: database_path)
+    {:ok, state} =
+      SQLite.init(
+        path: database_path,
+        instance_id: Atom.to_string(SQLiteMessaging)
+      )
+
     config = BridgeConfig.new(%{id: bridge_id, adapter_module: adapter_module, enabled: true})
     assert {:ok, ^config} = SQLite.save_bridge_config(state, config)
     :ok = Exqlite.Sqlite3.close(state.db)

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -167,6 +167,27 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :ok = Sqlite3.close(isolated.db)
   end
 
+  test "serializes concurrent legacy migration and keeps the first namespace owner" do
+    path = tmp_path("sqlite-concurrent-instance-migration")
+    room = Room.new(%{id: "room:legacy-race", type: :channel, name: "legacy-race"})
+    create_legacy_database(path, room)
+
+    states =
+      ["migration-one", "migration-two"]
+      |> Task.async_stream(fn instance_id -> SQLite.init(path: path, instance_id: instance_id) end,
+        ordered: false,
+        timeout: 10_000
+      )
+      |> Enum.map(fn {:ok, {:ok, state}} -> state end)
+
+    assert length(states) == 2
+
+    owners = Enum.filter(states, fn state -> match?({:ok, ^room}, SQLite.get_room(state, room.id)) end)
+    assert [_single_owner] = owners
+
+    Enum.each(states, fn state -> :ok = Sqlite3.close(state.db) end)
+  end
+
   test "normalizes non-string external binding values without crashing" do
     path = tmp_path("sqlite-normalized-bindings")
     {:ok, state} = SQLite.init(path: path)

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -9,6 +9,14 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     use Jido.Messaging, persistence: SQLite
   end
 
+  defmodule SQLiteMessagingOne do
+    use Jido.Messaging, persistence: SQLite
+  end
+
+  defmodule SQLiteMessagingTwo do
+    use Jido.Messaging, persistence: SQLite
+  end
+
   test "persists rooms, participants, threads, and messages across adapter restarts" do
     path = tmp_path("sqlite-durable")
     {:ok, state} = SQLite.init(path: path)
@@ -103,6 +111,60 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     assert {:ok, ^message} = SQLite.get_message_by_external_id(state, :slack, "workspace-1", "166000.100")
 
     :ok = Sqlite3.close(state.db)
+  end
+
+  test "isolates direct adapter instances that share one database" do
+    path = tmp_path("sqlite-instance-isolation")
+    {:ok, first} = SQLite.init(path: path, instance_id: "instance-one")
+    {:ok, second} = SQLite.init(path: path, instance_id: "instance-two")
+
+    first_room = Room.new(%{id: "room:shared-id", type: :channel, name: "first"})
+    second_room = Room.new(%{id: "room:shared-id", type: :channel, name: "second"})
+
+    assert {:ok, ^first_room} = SQLite.save_room(first, first_room)
+    assert {:error, :not_found} = SQLite.get_room(second, first_room.id)
+    assert {:ok, ^second_room} = SQLite.save_room(second, second_room)
+
+    assert {:ok, ^first_room} = SQLite.get_room(first, first_room.id)
+    assert {:ok, ^second_room} = SQLite.get_room(second, second_room.id)
+
+    assert :ok = SQLite.delete_room(first, first_room.id)
+    assert {:error, :not_found} = SQLite.get_room(first, first_room.id)
+    assert {:ok, ^second_room} = SQLite.get_room(second, second_room.id)
+
+    :ok = Sqlite3.close(first.db)
+    :ok = Sqlite3.close(second.db)
+  end
+
+  test "runtime modules receive separate default namespaces" do
+    path = tmp_path("sqlite-runtime-isolation")
+
+    start_supervised!({SQLiteMessagingOne, persistence_opts: [path: path]})
+    start_supervised!({SQLiteMessagingTwo, persistence_opts: [path: path]})
+
+    first_room = Room.new(%{id: "room:runtime-shared", type: :group, name: "runtime-one"})
+    second_room = Room.new(%{id: "room:runtime-shared", type: :group, name: "runtime-two"})
+
+    assert {:ok, ^first_room} = SQLiteMessagingOne.save_room(first_room)
+    assert {:error, :not_found} = SQLiteMessagingTwo.get_room(first_room.id)
+    assert {:ok, ^second_room} = SQLiteMessagingTwo.save_room(second_room)
+
+    assert {:ok, ^first_room} = SQLiteMessagingOne.get_room(first_room.id)
+    assert {:ok, ^second_room} = SQLiteMessagingTwo.get_room(second_room.id)
+  end
+
+  test "migrates legacy records into the opening instance namespace" do
+    path = tmp_path("sqlite-instance-migration")
+    room = Room.new(%{id: "room:legacy", type: :channel, name: "legacy"})
+    create_legacy_database(path, room)
+
+    {:ok, migrated} = SQLite.init(path: path, instance_id: "migrated-instance")
+    assert {:ok, ^room} = SQLite.get_room(migrated, room.id)
+    :ok = Sqlite3.close(migrated.db)
+
+    {:ok, isolated} = SQLite.init(path: path, instance_id: "other-instance")
+    assert {:error, :not_found} = SQLite.get_room(isolated, room.id)
+    :ok = Sqlite3.close(isolated.db)
   end
 
   test "normalizes non-string external binding values without crashing" do
@@ -301,5 +363,40 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
       inserted_at: inserted_at,
       thread_id: thread_id
     })
+  end
+
+  defp create_legacy_database(path, room) do
+    {:ok, db} = Sqlite3.open(path)
+
+    :ok =
+      Sqlite3.execute(db, """
+      CREATE TABLE jido_messaging_records (
+        kind TEXT NOT NULL,
+        id TEXT NOT NULL,
+        room_id TEXT,
+        thread_id TEXT,
+        inserted_at TEXT,
+        channel TEXT,
+        bridge_id TEXT,
+        external_id TEXT,
+        payload BLOB NOT NULL,
+        PRIMARY KEY (kind, id)
+      )
+      """)
+
+    {:ok, statement} =
+      Sqlite3.prepare(
+        db,
+        """
+        INSERT INTO jido_messaging_records
+          (kind, id, room_id, payload)
+        VALUES (?1, ?2, ?3, ?4)
+        """
+      )
+
+    :ok = Sqlite3.bind(statement, ["room", room.id, room.id, {:blob, :erlang.term_to_binary(room)}])
+    :done = Sqlite3.step(db, statement)
+    :ok = Sqlite3.release(db, statement)
+    :ok = Sqlite3.close(db)
   end
 end

--- a/test/jido_messaging/runtime_test.exs
+++ b/test/jido_messaging/runtime_test.exs
@@ -4,6 +4,10 @@ defmodule Jido.Messaging.RuntimeTest do
   alias Jido.Messaging.Runtime
   alias Jido.Messaging.Persistence.ETS
 
+  defmodule StrictOptionsPersistence do
+    def init(opts), do: {:ok, opts}
+  end
+
   describe "Runtime" do
     test "get_state/1 returns full runtime state" do
       {:ok, pid} =
@@ -35,6 +39,18 @@ defmodule Jido.Messaging.RuntimeTest do
 
       assert persistence == ETS
       assert is_struct(persistence_state, ETS)
+    end
+
+    test "does not add SQLite namespace options to custom persistence adapters" do
+      {:ok, pid} =
+        Runtime.start_link(
+          name: :test_runtime_strict_options,
+          instance_module: TestModule3,
+          persistence: StrictOptionsPersistence,
+          persistence_opts: [allowed: true]
+        )
+
+      assert {StrictOptionsPersistence, [allowed: true]} = Runtime.get_persistence(pid)
     end
   end
 end


### PR DESCRIPTION
## Summary

- add a stable instance namespace to every SQLite key, query, and index
- derive the default runtime namespace from the messaging module
- permit explicit stable namespace configuration for module renames
- migrate legacy records into the namespace that first opens the database
- test equal IDs, deletion isolation, runtime isolation, and legacy migration

## Verification

- SQLite persistence tests — 8 passed
- `mix test` — 539 passed, 4 skipped, 13 excluded

Closes #47