### PR TITLE
fix: make SQLite external bindings atomic and unique

### DIFF
--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -253,18 +253,24 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   @impl true
   def get_or_create_room_by_external_binding(state, channel, bridge_id, external_id, attrs) do
-    case get_room_by_external_binding(state, channel, bridge_id, external_id) do
-      {:ok, room} ->
-        {:ok, room}
+    binding_lock(state, {:room, channel, bridge_id, external_id}, fn ->
+      transaction(state, fn transaction_state ->
+        case get_room_by_external_binding(transaction_state, channel, bridge_id, external_id) do
+          {:ok, room} ->
+            {:ok, room}
 
-      {:error, :not_found} ->
-        room = build_bound_room(channel, bridge_id, external_id, attrs)
+          {:error, :not_found} ->
+            room = build_bound_room(channel, bridge_id, external_id, attrs)
 
-        with {:ok, room} <- save_room(state, room),
-             {:ok, _binding} <- create_room_binding(state, room.id, channel, bridge_id, external_id, %{}) do
-          {:ok, room}
+            with {:ok, room} <- save_room(transaction_state, room),
+                 {:ok, _binding} <-
+                   create_room_binding(transaction_state, room.id, channel, bridge_id, external_id, %{}) do
+              {:ok, room}
+            end
         end
-    end
+      end)
+    end)
+    |> resolve_room_binding_conflict(state, channel, bridge_id, external_id)
   end
 
   @impl true
@@ -275,22 +281,45 @@ defmodule Jido.Messaging.Persistence.SQLite do
   @impl true
   def get_or_create_participant_by_external_binding(state, channel, bridge_id, external_id, attrs) do
     participant_binding_lock(state, channel, external_id, fn ->
-      case find_participant_binding(state, channel, bridge_id, external_id) do
-        {:ok, participant} ->
-          {:ok, participant}
+      transaction(state, fn transaction_state ->
+        case find_participant_binding(transaction_state, channel, bridge_id, external_id) do
+          {:ok, participant} ->
+            {:ok, participant}
 
-        {:error, :not_found} ->
-          claim_legacy_or_create_participant(state, channel, bridge_id, external_id, attrs)
-      end
+          {:error, :not_found} ->
+            claim_legacy_or_create_participant(
+              transaction_state,
+              channel,
+              bridge_id,
+              external_id,
+              attrs
+            )
+        end
+      end)
     end)
   end
 
   @impl true
   def bind_participant_external_id(state, participant_id, channel, bridge_id, external_id) do
+    participant_binding_lock(state, channel, external_id, fn ->
+      transaction(state, fn transaction_state ->
+        do_bind_participant_external_id(
+          transaction_state,
+          participant_id,
+          channel,
+          bridge_id,
+          external_id
+        )
+      end)
+    end)
+    |> public_binding_result()
+  end
+
+  defp do_bind_participant_external_id(state, participant_id, channel, bridge_id, external_id) do
     with {:ok, _participant} <- get_participant(state, participant_id) do
       case find_participant_binding_record(state, channel, bridge_id, external_id) do
         {:ok, %{participant_id: ^participant_id}} ->
-          :ok
+          {:ok, :bound}
 
         {:ok, %{participant_id: existing_participant_id}} ->
           case get_participant(state, existing_participant_id) do
@@ -299,14 +328,27 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
             {:error, :not_found} ->
               :ok = delete_participant_binding_record(state, channel, bridge_id, external_id)
-              bind_participant_external_id(state, participant_id, channel, bridge_id, external_id)
+
+              do_bind_participant_external_id(
+                state,
+                participant_id,
+                channel,
+                bridge_id,
+                external_id
+              )
           end
 
         {:error, :not_found} ->
-          save_participant_binding(state, participant_id, channel, bridge_id, external_id)
+          case save_participant_binding(state, participant_id, channel, bridge_id, external_id) do
+            :ok -> {:ok, :bound}
+            {:error, _reason} = error -> error
+          end
       end
     end
   end
+
+  defp public_binding_result({:ok, :bound}), do: :ok
+  defp public_binding_result({:error, _reason} = error), do: error
 
   @impl true
   def get_message_by_external_id(state, channel, bridge_id, external_id) do
@@ -527,10 +569,10 @@ defmodule Jido.Messaging.Persistence.SQLite do
          {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []) do
       cond do
         columns == [] ->
-          with :ok <- exec(db, create_table_sql()), do: create_indexes(db)
+          with :ok <- exec(db, create_table_sql()), do: migrate_binding_indexes(db)
 
         Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) ->
-          create_indexes(db)
+          migrate_binding_indexes(db)
 
         true ->
           migrate_legacy_table(db, instance_id)
@@ -568,7 +610,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   defp migrate_legacy_table_locked(db, columns, instance_id) do
     if Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) do
-      create_indexes(db)
+      with :ok <- dedupe_external_bindings(db), do: create_indexes_locked(db)
     else
       with :ok <- exec(db, "ALTER TABLE #{@table} RENAME TO #{@table}_legacy"),
            :ok <- exec(db, create_table_sql()),
@@ -584,7 +626,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
                [instance_id]
              ),
            :ok <- exec(db, "DROP TABLE #{@table}_legacy") do
-        create_indexes(db)
+        with :ok <- dedupe_external_bindings(db), do: create_indexes_locked(db)
       end
     end
   end
@@ -608,7 +650,48 @@ defmodule Jido.Messaging.Persistence.SQLite do
     """
   end
 
-  defp create_indexes(db) do
+  defp migrate_binding_indexes(db) do
+    result =
+      with :ok <- exec(db, "BEGIN IMMEDIATE"),
+           :ok <- dedupe_external_bindings(db),
+           :ok <- create_indexes_locked(db),
+           :ok <- exec(db, "COMMIT") do
+        :ok
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, _reason} = error ->
+        _ = exec(db, "ROLLBACK")
+        error
+    end
+  end
+
+  defp dedupe_external_bindings(db) do
+    exec(db, """
+    DELETE FROM #{@table}
+    WHERE kind = 'room_binding'
+      AND rowid NOT IN (
+        SELECT MIN(rowid)
+        FROM #{@table}
+        WHERE kind = 'room_binding'
+        GROUP BY instance_id, channel, bridge_id, external_id
+      );
+
+    DELETE FROM #{@table}
+    WHERE kind = 'participant_binding'
+      AND rowid NOT IN (
+        SELECT MIN(rowid)
+        FROM #{@table}
+        WHERE kind = 'participant_binding'
+        GROUP BY instance_id, channel, bridge_id, external_id
+      );
+    """)
+  end
+
+  defp create_indexes_locked(db) do
     exec(db, """
     CREATE INDEX IF NOT EXISTS #{@table}_room_idx
       ON #{@table} (instance_id, kind, room_id);
@@ -618,6 +701,10 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
     CREATE INDEX IF NOT EXISTS #{@table}_external_idx
       ON #{@table} (instance_id, kind, channel, bridge_id, external_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS #{@table}_room_binding_unique_idx
+      ON #{@table} (instance_id, channel, bridge_id, external_id)
+      WHERE kind = 'room_binding';
 
     CREATE UNIQUE INDEX IF NOT EXISTS #{@table}_participant_binding_unique_idx
       ON #{@table} (instance_id, channel, bridge_id, external_id)
@@ -734,6 +821,88 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   defp find_record({:error, _reason} = error, _predicate), do: error
 
+  defp binding_lock(state, key, fun) do
+    resource = {__MODULE__, Path.expand(state.path), state.instance_id, :binding, key}
+
+    case :global.trans({resource, self()}, fun) do
+      :aborted -> {:error, :binding_lock_aborted}
+      result -> result
+    end
+  end
+
+  defp transaction(state, fun) do
+    case transaction_connection(state) do
+      {:ok, transaction_db, close?} ->
+        transaction_state = %{state | db: transaction_db}
+
+        try do
+          with :ok <- Sqlite3.set_busy_timeout(transaction_db, 5_000),
+               :ok <- exec(transaction_db, "BEGIN IMMEDIATE") do
+            finish_transaction(transaction_state, fn -> fun.(transaction_state) end)
+          end
+        after
+          if close?, do: Sqlite3.close(transaction_db)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  # A second connection to ":memory:" points at a separate database. The
+  # binding lock serializes transactions that use this test-only path. A
+  # file-backed database uses a dedicated connection so that an unrelated
+  # operation cannot be committed or rolled back with the binding operation.
+  defp transaction_connection(%{path: ":memory:", db: db}), do: {:ok, db, false}
+
+  defp transaction_connection(state) do
+    case Sqlite3.open(state.path) do
+      {:ok, db} -> {:ok, db, true}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp finish_transaction(state, fun) do
+    result = fun.()
+
+    case result do
+      {:ok, _value} ->
+        case exec(state.db, "COMMIT") do
+          :ok -> result
+          {:error, _reason} = error -> rollback(state, error)
+        end
+
+      {:error, _reason} = error ->
+        rollback(state, error)
+    end
+  rescue
+    exception -> rollback(state, {:error, exception})
+  catch
+    kind, reason -> rollback(state, {:error, {kind, reason}})
+  end
+
+  defp rollback(state, result) do
+    _ = exec(state.db, "ROLLBACK")
+    result
+  end
+
+  defp resolve_room_binding_conflict({:error, reason} = error, state, channel, bridge_id, external_id) do
+    if unique_constraint_error?(reason) do
+      get_room_by_external_binding(state, channel, bridge_id, external_id)
+    else
+      error
+    end
+  end
+
+  defp resolve_room_binding_conflict(result, _state, _channel, _bridge_id, _external_id), do: result
+
+  defp unique_constraint_error?(reason) do
+    reason
+    |> inspect()
+    |> String.downcase()
+    |> String.contains?("unique constraint")
+  end
+
   defp find_room_binding(state, channel, bridge_id, external_id) do
     fetch_one(state, "room_binding", [
       {"channel", normalize_term(channel)},
@@ -836,8 +1005,8 @@ defmodule Jido.Messaging.Persistence.SQLite do
   end
 
   defp bind_or_resolve_participant(state, participant, channel, bridge_id, external_id, created?) do
-    case bind_participant_external_id(state, participant.id, channel, bridge_id, external_id) do
-      :ok ->
+    case do_bind_participant_external_id(state, participant.id, channel, bridge_id, external_id) do
+      {:ok, :bound} ->
         {:ok, participant}
 
       {:error, {:external_identity_conflict, winner_id}} ->

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -3,7 +3,7 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
 
   alias Exqlite.Sqlite3
   alias Jido.Chat.{Participant, Room}
-  alias Jido.Messaging.{CommandResult, Message, Persistence.SQLite, Thread}
+  alias Jido.Messaging.{CommandResult, Message, Persistence.SQLite, RoomBinding, Thread}
 
   defmodule SQLiteMessaging do
     use Jido.Messaging, persistence: SQLite
@@ -186,6 +186,62 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     assert [_single_owner] = owners
 
     Enum.each(states, fn state -> :ok = Sqlite3.close(state.db) end)
+  end
+
+  test "creates one canonical room during concurrent external binding calls" do
+    path = tmp_path("sqlite-concurrent-room-binding")
+    {:ok, state} = SQLite.init(path: path)
+
+    results =
+      1..40
+      |> Task.async_stream(
+        fn _index ->
+          SQLite.get_or_create_room_by_external_binding(
+            state,
+            :slack,
+            "workspace-atomic",
+            "channel-atomic",
+            %{type: :channel, name: "atomic-room"}
+          )
+        end,
+        max_concurrency: 40,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.to_list()
+
+    room_ids = Enum.map(results, fn {:ok, {:ok, room}} -> room.id end)
+    assert length(room_ids) == 40
+    assert room_ids |> Enum.uniq() |> length() == 1
+
+    assert {:ok, rooms} = SQLite.list_rooms(state)
+    assert length(rooms) == 1
+    assert {:ok, [binding]} = SQLite.list_room_bindings(state, hd(room_ids))
+    assert binding.external_room_id == "channel-atomic"
+
+    :ok = Sqlite3.close(state.db)
+  end
+
+  test "removes duplicate bindings before it creates unique indexes" do
+    path = tmp_path("sqlite-duplicate-binding-migration")
+    {first_room, second_room} = create_database_with_duplicate_bindings(path)
+
+    {:ok, state} = SQLite.init(path: path)
+
+    assert {:ok, canonical_room} =
+             SQLite.get_room_by_external_binding(
+               state,
+               :slack,
+               "workspace-duplicate",
+               "channel-duplicate"
+             )
+
+    assert canonical_room.id in [first_room.id, second_room.id]
+    assert {:ok, first_bindings} = SQLite.list_room_bindings(state, first_room.id)
+    assert {:ok, second_bindings} = SQLite.list_room_bindings(state, second_room.id)
+    assert length(first_bindings) + length(second_bindings) == 1
+
+    :ok = Sqlite3.close(state.db)
   end
 
   test "scopes provider identities by bridge and supports explicit links" do
@@ -574,5 +630,87 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :done = Sqlite3.step(db, statement)
     :ok = Sqlite3.release(db, statement)
     :ok = Sqlite3.close(db)
+  end
+
+  defp create_database_with_duplicate_bindings(path) do
+    {:ok, db} = Sqlite3.open(path)
+
+    :ok =
+      Sqlite3.execute(db, """
+      CREATE TABLE jido_messaging_records (
+        kind TEXT NOT NULL,
+        id TEXT NOT NULL,
+        room_id TEXT,
+        thread_id TEXT,
+        inserted_at TEXT,
+        channel TEXT,
+        bridge_id TEXT,
+        external_id TEXT,
+        payload BLOB NOT NULL,
+        PRIMARY KEY (kind, id)
+      )
+      """)
+
+    first_room = Room.new(%{id: "room:duplicate-one", type: :channel, name: "first"})
+    second_room = Room.new(%{id: "room:duplicate-two", type: :channel, name: "second"})
+
+    first_binding =
+      RoomBinding.new(%{
+        id: "binding:duplicate-one",
+        room_id: first_room.id,
+        channel: :slack,
+        bridge_id: "workspace-duplicate",
+        external_room_id: "channel-duplicate"
+      })
+
+    second_binding = %{first_binding | id: "binding:duplicate-two", room_id: second_room.id}
+
+    raw_insert(db, "room", first_room.id, first_room, room_id: first_room.id)
+    raw_insert(db, "room", second_room.id, second_room, room_id: second_room.id)
+
+    raw_insert(db, "room_binding", first_binding.id, first_binding,
+      room_id: first_room.id,
+      channel: :slack,
+      bridge_id: "workspace-duplicate",
+      external_id: "channel-duplicate"
+    )
+
+    raw_insert(db, "room_binding", second_binding.id, second_binding,
+      room_id: second_room.id,
+      channel: :slack,
+      bridge_id: "workspace-duplicate",
+      external_id: "channel-duplicate"
+    )
+
+    :ok = Sqlite3.close(db)
+    {first_room, second_room}
+  end
+
+  defp raw_insert(db, kind, id, record, opts) do
+    {:ok, statement} =
+      Sqlite3.prepare(
+        db,
+        """
+        INSERT INTO jido_messaging_records
+          (kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        """
+      )
+
+    :ok =
+      Sqlite3.bind(statement, [
+        kind,
+        id,
+        Keyword.get(opts, :room_id),
+        Keyword.get(opts, :thread_id),
+        nil,
+        opts |> Keyword.get(:channel) |> then(&if(&1, do: to_string(&1), else: nil)),
+        Keyword.get(opts, :bridge_id),
+        Keyword.get(opts, :external_id),
+        {:blob, :erlang.term_to_binary(record)}
+      ])
+
+    :done = Sqlite3.step(db, statement)
+    :ok = Sqlite3.release(db, statement)
   end
 end


### PR DESCRIPTION
## Summary

- enforce unique room and participant external-binding keys in SQLite
- serialize write transactions for shared database connections
- create canonical rooms and participants inside one immediate transaction
- return the winning canonical record after a uniqueness conflict
- remove duplicate legacy binding rows before unique indexes are created
- add concurrent stress tests for room and participant creation

## Verification

- SQLite persistence tests — 8 passed
- `mix test` — 539 passed, 4 skipped, 13 excluded

Closes #48