### PR TITLE
fix: scope provider participant identity by bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ reading or replacing each other's records. Set `persistence_opts: [instance_id:
 Direct calls to `Jido.Messaging.Persistence.SQLite.init/1` use the explicit
 default namespace `"default"` unless `:instance_id` is supplied.
 
+Inbound participant identity is scoped by adapter and bridge ID. This prevents
+equal tenant-local provider IDs from merging participants across workspaces or
+server installations. Use `bind_participant_external_id/4` to link another
+provider identity to an existing canonical participant. Legacy unscoped calls
+use the explicit `"default"` bridge scope. SQLite assigns an unclaimed legacy
+participant record to the first matching scoped identity; applications can use
+the binding API before traffic starts when a different migration is required.
+
 ### Presence Signals
 
 `Jido.Messaging.Presence` bridges transport-specific presence state, such as

--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -255,6 +255,28 @@ defmodule Jido.Messaging do
         )
       end
 
+      @doc "Get or create a participant by bridge-scoped external identity"
+      def get_or_create_participant_by_external_id(channel, bridge_id, external_id, attrs) do
+        Jido.Messaging.get_or_create_participant_by_external_id(
+          __jido_messaging__(:runtime),
+          channel,
+          bridge_id,
+          external_id,
+          attrs
+        )
+      end
+
+      @doc "Bind a bridge-scoped external identity to an existing participant"
+      def bind_participant_external_id(participant_id, channel, bridge_id, external_id) do
+        Jido.Messaging.bind_participant_external_id(
+          __jido_messaging__(:runtime),
+          participant_id,
+          channel,
+          bridge_id,
+          external_id
+        )
+      end
+
       @doc "Get a message by its external ID within a channel/bridge context"
       def get_message_by_external_id(channel, bridge_id, external_id) do
         Jido.Messaging.get_message_by_external_id(
@@ -840,8 +862,41 @@ defmodule Jido.Messaging do
 
   @doc "Get or create participant by external ID"
   def get_or_create_participant_by_external_id(runtime, channel, external_id, attrs) do
+    get_or_create_participant_by_external_id(runtime, channel, "default", external_id, attrs)
+  end
+
+  @doc "Get or create a participant by bridge-scoped external identity"
+  def get_or_create_participant_by_external_id(runtime, channel, bridge_id, external_id, attrs) do
     {persistence, persistence_state} = Runtime.get_persistence(runtime)
-    persistence.get_or_create_participant_by_external_id(persistence_state, channel, external_id, attrs)
+
+    if function_exported?(persistence, :get_or_create_participant_by_external_binding, 5) do
+      persistence.get_or_create_participant_by_external_binding(
+        persistence_state,
+        channel,
+        bridge_id,
+        external_id,
+        attrs
+      )
+    else
+      persistence.get_or_create_participant_by_external_id(persistence_state, channel, external_id, attrs)
+    end
+  end
+
+  @doc "Bind a bridge-scoped external identity to an existing participant"
+  def bind_participant_external_id(runtime, participant_id, channel, bridge_id, external_id) do
+    {persistence, persistence_state} = Runtime.get_persistence(runtime)
+
+    if function_exported?(persistence, :bind_participant_external_id, 5) do
+      persistence.bind_participant_external_id(
+        persistence_state,
+        participant_id,
+        channel,
+        bridge_id,
+        external_id
+      )
+    else
+      {:error, :unsupported}
+    end
   end
 
   @doc "Get a message by its external ID within a channel/instance context"

--- a/lib/jido_messaging/ingest.ex
+++ b/lib/jido_messaging/ingest.ex
@@ -215,7 +215,7 @@ defmodule Jido.Messaging.Ingest do
            Security.verify_sender(messaging_module, channel_module, incoming, raw_payload, opts),
          {:ok, room} <- resolve_room(messaging_module, channel_type, bridge_id, incoming),
          {:ok, room_server} <- RoomSupervisor.get_or_start_room(messaging_module, room),
-         {:ok, participant} <- resolve_participant(messaging_module, channel_type, incoming),
+         {:ok, participant} <- resolve_participant(messaging_module, channel_type, bridge_id, incoming),
          msg_context <- build_msg_context(channel_module, bridge_id, incoming, room, participant, opts),
          {:ok, thread} <-
            resolve_thread_scope(
@@ -341,7 +341,7 @@ defmodule Jido.Messaging.Ingest do
     )
   end
 
-  defp resolve_participant(messaging_module, channel_type, incoming) do
+  defp resolve_participant(messaging_module, channel_type, bridge_id, incoming) do
     external_id = to_string(incoming.external_user_id)
 
     participant_attrs = %{
@@ -354,6 +354,7 @@ defmodule Jido.Messaging.Ingest do
 
     messaging_module.get_or_create_participant_by_external_id(
       channel_type,
+      bridge_id,
       external_id,
       participant_attrs
     )

--- a/lib/jido_messaging/persistence.ex
+++ b/lib/jido_messaging/persistence.ex
@@ -130,6 +130,24 @@ defmodule Jido.Messaging.Persistence do
               attrs :: map()
             ) :: {:ok, Participant.t()}
 
+  @doc """
+  Get or create a participant from a bridge-scoped provider identity.
+
+  The bridge ID is the provider tenant or installation scope. Adapters that do
+  not implement this callback use the legacy channel-scoped callback.
+  """
+  @callback get_or_create_participant_by_external_binding(
+              state,
+              channel,
+              bridge_id,
+              external_id,
+              attrs :: map()
+            ) :: {:ok, Participant.t()}
+
+  @doc "Bind a bridge-scoped provider identity to an existing participant."
+  @callback bind_participant_external_id(state, participant_id, channel, bridge_id, external_id) ::
+              :ok | {:error, :not_found | {:external_identity_conflict, participant_id}}
+
   # Message external ID operations (for reply/quote mapping)
   @doc """
   Get a message by its external ID within a channel/instance context.
@@ -225,7 +243,9 @@ defmodule Jido.Messaging.Persistence do
   @doc "Delete stored ingress subscription metadata."
   @callback delete_ingress_subscription(state, bridge_id(), String.t()) :: :ok | {:error, :not_found}
 
-  @optional_callbacks save_ingress_subscription: 2,
+  @optional_callbacks get_or_create_participant_by_external_binding: 5,
+                      bind_participant_external_id: 5,
+                      save_ingress_subscription: 2,
                       list_ingress_subscriptions: 3,
                       delete_ingress_subscription: 3
 

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -367,7 +367,12 @@ defmodule Jido.Messaging.Persistence.ETS do
 
   @impl true
   def get_or_create_participant_by_external_id(state, channel, external_id, attrs) do
-    binding_key = {channel, external_id}
+    get_or_create_participant_by_external_binding(state, channel, "default", external_id, attrs)
+  end
+
+  @impl true
+  def get_or_create_participant_by_external_binding(state, channel, bridge_id, external_id, attrs) do
+    binding_key = participant_binding_key(channel, bridge_id, external_id)
 
     case :ets.lookup(state.participant_bindings, binding_key) do
       [{^binding_key, participant_id}] ->
@@ -378,7 +383,14 @@ defmodule Jido.Messaging.Persistence.ETS do
           {:error, :not_found} ->
             # Remove stale binding only if it still points at the missing participant.
             true = :ets.delete_object(state.participant_bindings, {binding_key, participant_id})
-            get_or_create_participant_by_external_id(state, channel, external_id, attrs)
+
+            get_or_create_participant_by_external_binding(
+              state,
+              channel,
+              bridge_id,
+              external_id,
+              attrs
+            )
         end
 
       [] ->
@@ -392,6 +404,27 @@ defmodule Jido.Messaging.Persistence.ETS do
           false ->
             resolve_participant_binding_race(state, binding_key, participant.id)
         end
+    end
+  end
+
+  @impl true
+  def bind_participant_external_id(state, participant_id, channel, bridge_id, external_id) do
+    with {:ok, _participant} <- get_participant(state, participant_id) do
+      binding_key = participant_binding_key(channel, bridge_id, external_id)
+
+      case :ets.insert_new(state.participant_bindings, {binding_key, participant_id}) do
+        true ->
+          :ok
+
+        false ->
+          case :ets.lookup(state.participant_bindings, binding_key) do
+            [{^binding_key, ^participant_id}] ->
+              :ok
+
+            [{^binding_key, existing_participant_id}] ->
+              {:error, {:external_identity_conflict, existing_participant_id}}
+          end
+      end
     end
   end
 
@@ -853,6 +886,10 @@ defmodule Jido.Messaging.Persistence.ETS do
   defp normalize_term(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_term(value) when is_integer(value), do: Integer.to_string(value)
   defp normalize_term(value), do: inspect(value)
+
+  defp participant_binding_key(channel, bridge_id, external_id) do
+    {channel, normalize_term(bridge_id), normalize_term(external_id)}
+  end
 
   defp build_bound_room(channel, bridge_id, external_id, attrs) do
     Room.new(

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -103,10 +103,11 @@ defmodule Jido.Messaging.Persistence.SQLite do
       state.db,
       """
       DELETE FROM #{@table}
-      WHERE (kind = 'participant' AND id = ?1)
-         OR (kind = 'participant_binding' AND room_id = ?1)
+      WHERE instance_id = ?1
+        AND ((kind = 'participant' AND id = ?2)
+          OR (kind = 'participant_binding' AND room_id = ?2))
       """,
-      [participant_id]
+      [state.instance_id, participant_id]
     )
   end
 
@@ -797,11 +798,12 @@ defmodule Jido.Messaging.Persistence.SQLite do
              state.db,
              """
              INSERT INTO #{@table}
-               (kind, id, room_id, channel, bridge_id, external_id, payload)
-             VALUES ('participant_binding', ?1, ?2, ?3, ?4, ?5, ?6)
+               (instance_id, kind, id, room_id, channel, bridge_id, external_id, payload)
+             VALUES (?1, 'participant_binding', ?2, ?3, ?4, ?5, ?6, ?7)
              ON CONFLICT DO NOTHING
              """,
              [
+               state.instance_id,
                id,
                participant_id,
                normalized_channel,
@@ -860,6 +862,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
     resource = {
       __MODULE__,
       Path.expand(state.path),
+      state.instance_id,
       :participant_binding,
       normalize_term(channel),
       normalize_term(external_id)

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -260,13 +260,52 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   @impl true
   def get_or_create_participant_by_external_id(state, channel, external_id, attrs) do
-    case find_participant_by_external_id(state, channel, external_id) do
+    case find_participant_binding(state, channel, "default", external_id) do
+      {:ok, participant} ->
+        {:ok, participant}
+
+      {:error, :not_found} ->
+        case find_unclaimed_legacy_participant(state, channel, external_id) do
+          {:ok, participant} ->
+            with :ok <- bind_participant_external_id(state, participant.id, channel, "default", external_id) do
+              {:ok, participant}
+            end
+
+          {:error, :not_found} ->
+            get_or_create_participant_by_external_binding(state, channel, "default", external_id, attrs)
+        end
+    end
+  end
+
+  @impl true
+  def get_or_create_participant_by_external_binding(state, channel, bridge_id, external_id, attrs) do
+    case find_participant_binding(state, channel, bridge_id, external_id) do
       {:ok, participant} ->
         {:ok, participant}
 
       {:error, :not_found} ->
         participant = build_bound_participant(channel, external_id, attrs)
-        save_participant(state, participant)
+
+        with {:ok, participant} <- save_participant(state, participant),
+             :ok <- bind_participant_external_id(state, participant.id, channel, bridge_id, external_id) do
+          {:ok, participant}
+        end
+    end
+  end
+
+  @impl true
+  def bind_participant_external_id(state, participant_id, channel, bridge_id, external_id) do
+    with {:ok, _participant} <- get_participant(state, participant_id) do
+      case find_participant_binding_record(state, channel, bridge_id, external_id) do
+        {:ok, %{participant_id: ^participant_id}} ->
+          :ok
+
+        {:ok, %{participant_id: existing_participant_id}} ->
+          {:error, {:external_identity_conflict, existing_participant_id}}
+
+        {:error, :not_found} ->
+          save_participant_binding(state, participant_id, channel, bridge_id, external_id)
+      end
     end
   end
 
@@ -580,6 +619,10 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
     CREATE INDEX IF NOT EXISTS #{@table}_external_idx
       ON #{@table} (instance_id, kind, channel, bridge_id, external_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS #{@table}_participant_binding_unique_idx
+      ON #{@table} (instance_id, channel, bridge_id, external_id)
+      WHERE kind = 'participant_binding';
     """)
   end
 
@@ -704,6 +747,61 @@ defmodule Jido.Messaging.Persistence.SQLite do
     state
     |> list_records("participant", limit: 500)
     |> find_record(&participant_external_id_matches?(&1, %{channel: channel, external_id: external_id}))
+  end
+
+  defp find_participant_binding(state, channel, bridge_id, external_id) do
+    with {:ok, binding} <- find_participant_binding_record(state, channel, bridge_id, external_id) do
+      get_participant(state, binding.participant_id)
+    end
+  end
+
+  defp find_participant_binding_record(state, channel, bridge_id, external_id) do
+    fetch_one(state, "participant_binding", [
+      {"channel", normalize_term(channel)},
+      {"bridge_id", normalize_term(bridge_id)},
+      {"external_id", normalize_term(external_id)}
+    ])
+  end
+
+  defp find_unclaimed_legacy_participant(state, channel, external_id) do
+    case fetch_one(state, "participant_binding", [
+           {"channel", normalize_term(channel)},
+           {"external_id", normalize_term(external_id)}
+         ]) do
+      {:ok, _binding} -> {:error, :not_found}
+      {:error, :not_found} -> find_participant_by_external_id(state, channel, external_id)
+    end
+  end
+
+  defp save_participant_binding(state, participant_id, channel, bridge_id, external_id) do
+    normalized_channel = normalize_term(channel)
+    normalized_bridge_id = normalize_term(bridge_id)
+    normalized_external_id = normalize_term(external_id)
+
+    binding = %{
+      participant_id: participant_id,
+      channel: normalized_channel,
+      bridge_id: normalized_bridge_id,
+      external_id: normalized_external_id
+    }
+
+    case persist(
+           state,
+           "participant_binding",
+           participant_binding_id(normalized_channel, normalized_bridge_id, normalized_external_id),
+           binding,
+           channel: normalized_channel,
+           bridge_id: normalized_bridge_id,
+           external_id: normalized_external_id
+         ) do
+      {:ok, _binding} -> :ok
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp participant_binding_id(channel, bridge_id, external_id) do
+    digest = :crypto.hash(:sha256, :erlang.term_to_binary({channel, bridge_id, external_id}))
+    "participant_binding:" <> Base.url_encode64(digest, padding: false)
   end
 
   defp participant_matches?(participant, query) do

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -99,7 +99,15 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   @impl true
   def delete_participant(state, participant_id) do
-    delete_record(state, "participant", participant_id)
+    run(
+      state.db,
+      """
+      DELETE FROM #{@table}
+      WHERE (kind = 'participant' AND id = ?1)
+         OR (kind = 'participant_binding' AND room_id = ?1)
+      """,
+      [participant_id]
+    )
   end
 
   @impl true
@@ -260,37 +268,20 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   @impl true
   def get_or_create_participant_by_external_id(state, channel, external_id, attrs) do
-    case find_participant_binding(state, channel, "default", external_id) do
-      {:ok, participant} ->
-        {:ok, participant}
-
-      {:error, :not_found} ->
-        case find_unclaimed_legacy_participant(state, channel, external_id) do
-          {:ok, participant} ->
-            with :ok <- bind_participant_external_id(state, participant.id, channel, "default", external_id) do
-              {:ok, participant}
-            end
-
-          {:error, :not_found} ->
-            get_or_create_participant_by_external_binding(state, channel, "default", external_id, attrs)
-        end
-    end
+    get_or_create_participant_by_external_binding(state, channel, "default", external_id, attrs)
   end
 
   @impl true
   def get_or_create_participant_by_external_binding(state, channel, bridge_id, external_id, attrs) do
-    case find_participant_binding(state, channel, bridge_id, external_id) do
-      {:ok, participant} ->
-        {:ok, participant}
-
-      {:error, :not_found} ->
-        participant = build_bound_participant(channel, external_id, attrs)
-
-        with {:ok, participant} <- save_participant(state, participant),
-             :ok <- bind_participant_external_id(state, participant.id, channel, bridge_id, external_id) do
+    participant_binding_lock(state, channel, external_id, fn ->
+      case find_participant_binding(state, channel, bridge_id, external_id) do
+        {:ok, participant} ->
           {:ok, participant}
-        end
-    end
+
+        {:error, :not_found} ->
+          claim_legacy_or_create_participant(state, channel, bridge_id, external_id, attrs)
+      end
+    end)
   end
 
   @impl true
@@ -301,7 +292,14 @@ defmodule Jido.Messaging.Persistence.SQLite do
           :ok
 
         {:ok, %{participant_id: existing_participant_id}} ->
-          {:error, {:external_identity_conflict, existing_participant_id}}
+          case get_participant(state, existing_participant_id) do
+            {:ok, _participant} ->
+              {:error, {:external_identity_conflict, existing_participant_id}}
+
+            {:error, :not_found} ->
+              :ok = delete_participant_binding_record(state, channel, bridge_id, external_id)
+              bind_participant_external_id(state, participant_id, channel, bridge_id, external_id)
+          end
 
         {:error, :not_found} ->
           save_participant_binding(state, participant_id, channel, bridge_id, external_id)
@@ -751,7 +749,14 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   defp find_participant_binding(state, channel, bridge_id, external_id) do
     with {:ok, binding} <- find_participant_binding_record(state, channel, bridge_id, external_id) do
-      get_participant(state, binding.participant_id)
+      case get_participant(state, binding.participant_id) do
+        {:ok, participant} ->
+          {:ok, participant}
+
+        {:error, :not_found} ->
+          :ok = delete_participant_binding_record(state, channel, bridge_id, external_id)
+          {:error, :not_found}
+      end
     end
   end
 
@@ -785,17 +790,84 @@ defmodule Jido.Messaging.Persistence.SQLite do
       external_id: normalized_external_id
     }
 
-    case persist(
-           state,
-           "participant_binding",
-           participant_binding_id(normalized_channel, normalized_bridge_id, normalized_external_id),
-           binding,
-           channel: normalized_channel,
-           bridge_id: normalized_bridge_id,
-           external_id: normalized_external_id
-         ) do
-      {:ok, _binding} -> :ok
-      {:error, _reason} = error -> error
+    id = participant_binding_id(normalized_channel, normalized_bridge_id, normalized_external_id)
+
+    with :ok <-
+           run(
+             state.db,
+             """
+             INSERT INTO #{@table}
+               (kind, id, room_id, channel, bridge_id, external_id, payload)
+             VALUES ('participant_binding', ?1, ?2, ?3, ?4, ?5, ?6)
+             ON CONFLICT DO NOTHING
+             """,
+             [
+               id,
+               participant_id,
+               normalized_channel,
+               normalized_bridge_id,
+               normalized_external_id,
+               {:blob, :erlang.term_to_binary(binding)}
+             ]
+           ),
+         {:ok, stored_binding} <- find_participant_binding_record(state, channel, bridge_id, external_id) do
+      if stored_binding.participant_id == participant_id do
+        :ok
+      else
+        {:error, {:external_identity_conflict, stored_binding.participant_id}}
+      end
+    end
+  end
+
+  defp claim_legacy_or_create_participant(state, channel, bridge_id, external_id, attrs) do
+    case find_unclaimed_legacy_participant(state, channel, external_id) do
+      {:ok, participant} ->
+        bind_or_resolve_participant(state, participant, channel, bridge_id, external_id, false)
+
+      {:error, :not_found} ->
+        participant = build_bound_participant(channel, external_id, attrs)
+
+        with {:ok, participant} <- save_participant(state, participant) do
+          bind_or_resolve_participant(state, participant, channel, bridge_id, external_id, true)
+        end
+    end
+  end
+
+  defp bind_or_resolve_participant(state, participant, channel, bridge_id, external_id, created?) do
+    case bind_participant_external_id(state, participant.id, channel, bridge_id, external_id) do
+      :ok ->
+        {:ok, participant}
+
+      {:error, {:external_identity_conflict, winner_id}} ->
+        if created?, do: delete_participant(state, participant.id)
+        get_participant(state, winner_id)
+
+      {:error, _reason} = error ->
+        if created?, do: delete_participant(state, participant.id)
+        error
+    end
+  end
+
+  defp delete_participant_binding_record(state, channel, bridge_id, external_id) do
+    delete_record(
+      state,
+      "participant_binding",
+      participant_binding_id(normalize_term(channel), normalize_term(bridge_id), normalize_term(external_id))
+    )
+  end
+
+  defp participant_binding_lock(state, channel, external_id, fun) do
+    resource = {
+      __MODULE__,
+      Path.expand(state.path),
+      :participant_binding,
+      normalize_term(channel),
+      normalize_term(external_id)
+    }
+
+    case :global.trans({resource, self()}, fun) do
+      :aborted -> {:error, :participant_binding_lock_aborted}
+      result -> result
     end
   end
 

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -353,6 +353,58 @@ defmodule Jido.Messaging.IngestTest do
       assert Enum.count(results, &(&1 == {:ok, :duplicate})) == 19
     end
 
+    test "keeps equal provider user IDs separate across bridges" do
+      incoming = %{
+        external_room_id: "chat_identity_scope",
+        external_user_id: "tenant-local-user",
+        text: "Scoped identity",
+        external_message_id: "identity-message-a"
+      }
+
+      assert {:ok, first_message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "tenant-a", incoming)
+
+      assert {:ok, second_message, _context} =
+               Ingest.ingest_incoming(
+                 TestMessaging,
+                 MockChannel,
+                 "tenant-b",
+                 %{incoming | external_message_id: "identity-message-b"}
+               )
+
+      refute first_message.sender_id == second_message.sender_id
+    end
+
+    test "uses an explicit identity link across bridges" do
+      assert {:ok, participant} =
+               TestMessaging.get_or_create_participant_by_external_id(
+                 :mock,
+                 "tenant-link-a",
+                 "provider-user-a",
+                 %{type: :human, identity: %{display_name: "Linked User"}}
+               )
+
+      assert :ok =
+               TestMessaging.bind_participant_external_id(
+                 participant.id,
+                 :mock,
+                 "tenant-link-b",
+                 "provider-user-b"
+               )
+
+      incoming = %{
+        external_room_id: "chat_linked_identity",
+        external_user_id: "provider-user-b",
+        text: "Linked identity",
+        external_message_id: "linked-message"
+      }
+
+      assert {:ok, message, _context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "tenant-link-b", incoming)
+
+      assert message.sender_id == participant.id
+    end
+
     test "reuses existing room for same external binding" do
       incoming = %{
         external_room_id: "chat_same",

--- a/test/jido_messaging/persistence/ets_test.exs
+++ b/test/jido_messaging/persistence/ets_test.exs
@@ -56,6 +56,59 @@ defmodule Jido.Messaging.Persistence.ETSTest do
       assert {:ok, fetched} = ETS.get_participant(state, participant.id)
       assert fetched.identity.name == "Alice"
     end
+
+    test "scopes provider identities by bridge and supports explicit links", %{state: state} do
+      assert {:ok, first} =
+               ETS.get_or_create_participant_by_external_binding(
+                 state,
+                 :slack,
+                 "workspace-one",
+                 "user-1",
+                 %{type: :human, identity: %{name: "First"}}
+               )
+
+      assert {:ok, second} =
+               ETS.get_or_create_participant_by_external_binding(
+                 state,
+                 :slack,
+                 "workspace-two",
+                 "user-1",
+                 %{type: :human, identity: %{name: "Second"}}
+               )
+
+      refute first.id == second.id
+
+      assert :ok =
+               ETS.bind_participant_external_id(
+                 state,
+                 first.id,
+                 :slack,
+                 "workspace-three",
+                 "user-linked"
+               )
+
+      assert {:ok, linked} =
+               ETS.get_or_create_participant_by_external_binding(
+                 state,
+                 :slack,
+                 "workspace-three",
+                 "user-linked",
+                 %{}
+               )
+
+      assert linked.id == first.id
+
+      assert {:error, {:external_identity_conflict, first_id}} =
+               ETS.bind_participant_external_id(
+                 state,
+                 second.id,
+                 :slack,
+                 "workspace-three",
+                 "user-linked"
+               )
+
+      assert first_id == first.id
+    end
   end
 
   describe "message operations" do

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -188,6 +188,63 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     Enum.each(states, fn state -> :ok = Sqlite3.close(state.db) end)
   end
 
+  test "scopes provider identities by bridge and supports explicit links" do
+    path = tmp_path("sqlite-participant-scope")
+    {:ok, state} = SQLite.init(path: path)
+
+    assert {:ok, first} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-one",
+               "user-1",
+               %{type: :human, identity: %{name: "First"}}
+             )
+
+    assert {:ok, second} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-two",
+               "user-1",
+               %{type: :human, identity: %{name: "Second"}}
+             )
+
+    refute first.id == second.id
+
+    assert :ok =
+             SQLite.bind_participant_external_id(
+               state,
+               first.id,
+               :slack,
+               "workspace-three",
+               "user-linked"
+             )
+
+    assert {:ok, linked} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-three",
+               "user-linked",
+               %{}
+             )
+
+    assert linked.id == first.id
+
+    assert {:error, {:external_identity_conflict, first_id}} =
+             SQLite.bind_participant_external_id(
+               state,
+               second.id,
+               :slack,
+               "workspace-three",
+               "user-linked"
+             )
+
+    assert first_id == first.id
+    :ok = Sqlite3.close(state.db)
+  end
+
   test "normalizes non-string external binding values without crashing" do
     path = tmp_path("sqlite-normalized-bindings")
     {:ok, state} = SQLite.init(path: path)

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -245,6 +245,103 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :ok = Sqlite3.close(state.db)
   end
 
+  test "claims a matching legacy participant for a scoped provider identity" do
+    path = tmp_path("sqlite-participant-legacy-claim")
+    {:ok, state} = SQLite.init(path: path)
+
+    legacy =
+      Participant.new(%{
+        id: "participant:legacy",
+        type: :human,
+        identity: %{name: "Legacy User"},
+        external_ids: %{slack: "user-legacy"}
+      })
+
+    assert {:ok, ^legacy} = SQLite.save_participant(state, legacy)
+
+    assert {:ok, claimed} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-one",
+               "user-legacy",
+               %{type: :human, identity: %{name: "Replacement"}}
+             )
+
+    assert claimed.id == legacy.id
+
+    assert {:ok, same_participant} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-one",
+               "user-legacy",
+               %{}
+             )
+
+    assert same_participant.id == legacy.id
+    :ok = Sqlite3.close(state.db)
+  end
+
+  test "creates one participant during concurrent scoped identity claims" do
+    path = tmp_path("sqlite-participant-concurrent-claim")
+    {:ok, state} = SQLite.init(path: path)
+
+    results =
+      1..40
+      |> Task.async_stream(
+        fn _index ->
+          SQLite.get_or_create_participant_by_external_binding(
+            state,
+            :slack,
+            "workspace-one",
+            "user-concurrent",
+            %{type: :human, identity: %{name: "Concurrent User"}}
+          )
+        end,
+        max_concurrency: 40,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.to_list()
+
+    participant_ids = Enum.map(results, fn {:ok, {:ok, participant}} -> participant.id end)
+    assert length(participant_ids) == 40
+    assert participant_ids |> Enum.uniq() |> length() == 1
+
+    assert {:ok, participants} = SQLite.directory_search(state, :participant, %{}, [])
+    assert length(participants) == 1
+    :ok = Sqlite3.close(state.db)
+  end
+
+  test "deleting a participant releases its scoped identity" do
+    path = tmp_path("sqlite-participant-delete-binding")
+    {:ok, state} = SQLite.init(path: path)
+
+    assert {:ok, original} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-one",
+               "user-replaced",
+               %{type: :human, identity: %{name: "Original"}}
+             )
+
+    assert :ok = SQLite.delete_participant(state, original.id)
+
+    assert {:ok, replacement} =
+             SQLite.get_or_create_participant_by_external_binding(
+               state,
+               :slack,
+               "workspace-one",
+               "user-replaced",
+               %{type: :human, identity: %{name: "Replacement"}}
+             )
+
+    refute replacement.id == original.id
+    :ok = Sqlite3.close(state.db)
+  end
+
   test "normalizes non-string external binding values without crashing" do
     path = tmp_path("sqlite-normalized-bindings")
     {:ok, state} = SQLite.init(path: path)

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -513,6 +513,7 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
 
   defp tmp_path(prefix) do
     path = Path.join(["tmp", "#{prefix}-#{System.unique_integer([:positive])}.sqlite3"])
+    File.mkdir_p!(Path.dirname(path))
     File.rm(path)
     path
   end


### PR DESCRIPTION
## Summary

- resolve inbound participants by adapter, bridge, and provider user ID
- preserve the legacy unscoped API through an explicit `default` bridge scope
- add an API to link more provider identities to one canonical participant
- reject an attempted link when that scoped identity belongs to another participant
- persist scoped participant bindings in ETS and SQLite
- document legacy SQLite identity assignment

## Verification

- identity, ingest, and persistence tests — 56 passed
- `mix test` — 540 passed, 4 skipped, 13 excluded

Closes #53