### PR TITLE
test(persistence): publish adapter conformance contract

### DIFF
--- a/lib/jido_messaging/persistence/conformance.ex
+++ b/lib/jido_messaging/persistence/conformance.ex
@@ -1,0 +1,313 @@
+defmodule Jido.Messaging.Persistence.Conformance do
+  @moduledoc """
+  Reusable ExUnit contract for persistence adapters.
+
+  Use this module in an adapter test. Give it a factory that starts a new
+  adapter instance and a cleanup function that stops that instance.
+
+      defmodule MyAdapterConformanceTest do
+        use Jido.Messaging.Persistence.Conformance,
+          adapter: MyAdapter,
+          factory: {MyAdapterFactory, :start, []},
+          cleanup: {MyAdapterFactory, :stop, []}
+      end
+
+  The factory must return `{:ok, state}`. The cleanup function receives the
+  state as its first argument. Extra arguments in each MFA tuple follow the
+  state argument.
+
+  The suite starts a new adapter instance for each test. It also starts two
+  instances for the isolation contract. A factory must therefore create a
+  separate storage scope on each call.
+  """
+
+  @doc false
+  defmacro __using__(opts) do
+    adapter = Keyword.fetch!(opts, :adapter)
+    factory = Keyword.fetch!(opts, :factory)
+    cleanup = Keyword.fetch!(opts, :cleanup)
+    async? = Keyword.get(opts, :async, false)
+
+    quote bind_quoted: [adapter: adapter, factory: factory, cleanup: cleanup, async?: async?] do
+      use ExUnit.Case, async: async?
+
+      alias Jido.Chat.{Participant, Room}
+      alias Jido.Messaging.{Message, Thread}
+
+      @persistence_adapter adapter
+      @persistence_factory factory
+      @persistence_cleanup cleanup
+
+      setup do
+        {:ok, state} = Jido.Messaging.Persistence.Conformance.start(@persistence_factory)
+
+        on_exit(fn ->
+          Jido.Messaging.Persistence.Conformance.stop(@persistence_cleanup, state)
+        end)
+
+        {:ok, persistence: state}
+      end
+
+      test "returns not_found for records that do not exist", %{persistence: state} do
+        assert {:error, :not_found} = @persistence_adapter.get_room(state, "missing-room")
+        assert {:error, :not_found} = @persistence_adapter.get_participant(state, "missing-participant")
+        assert {:error, :not_found} = @persistence_adapter.get_thread(state, "missing-thread")
+        assert {:error, :not_found} = @persistence_adapter.get_message(state, "missing-message")
+      end
+
+      test "keeps adapter instances isolated", %{persistence: first} do
+        {:ok, second} = Jido.Messaging.Persistence.Conformance.start(@persistence_factory)
+
+        on_exit(fn ->
+          Jido.Messaging.Persistence.Conformance.stop(@persistence_cleanup, second)
+        end)
+
+        room = Room.new(%{id: unique_id("room"), type: :direct})
+        assert {:ok, ^room} = @persistence_adapter.save_room(first, room)
+        assert {:error, :not_found} = @persistence_adapter.get_room(second, room.id)
+      end
+
+      test "round-trips and deletes core records", %{persistence: state} do
+        room = Room.new(%{id: unique_id("room"), type: :group, name: "Contract room"})
+
+        participant =
+          Participant.new(%{
+            id: unique_id("participant"),
+            type: :human,
+            identity: %{name: "Contract user"}
+          })
+
+        thread =
+          Thread.new(%{
+            id: unique_id("thread"),
+            room_id: room.id,
+            external_thread_id: unique_id("external-thread"),
+            root_message_id: unique_id("root-message")
+          })
+
+        message = contract_message(room.id, unique_id("message"), participant.id)
+
+        assert {:ok, ^room} = @persistence_adapter.save_room(state, room)
+        assert {:ok, ^participant} = @persistence_adapter.save_participant(state, participant)
+        assert {:ok, ^thread} = @persistence_adapter.save_thread(state, thread)
+        assert {:ok, ^message} = @persistence_adapter.save_message(state, message)
+
+        assert {:ok, ^room} = @persistence_adapter.get_room(state, room.id)
+        assert {:ok, ^participant} = @persistence_adapter.get_participant(state, participant.id)
+        assert {:ok, ^thread} = @persistence_adapter.get_thread(state, thread.id)
+        assert {:ok, ^message} = @persistence_adapter.get_message(state, message.id)
+
+        assert {:ok, ^thread} =
+                 @persistence_adapter.get_thread_by_external_id(
+                   state,
+                   room.id,
+                   thread.external_thread_id
+                 )
+
+        assert {:ok, ^thread} =
+                 @persistence_adapter.get_thread_by_root_message(
+                   state,
+                   room.id,
+                   thread.root_message_id
+                 )
+
+        assert :ok = @persistence_adapter.delete_message(state, message.id)
+        assert :ok = @persistence_adapter.delete_participant(state, participant.id)
+        assert {:error, :not_found} = @persistence_adapter.get_message(state, message.id)
+        assert {:error, :not_found} = @persistence_adapter.get_participant(state, participant.id)
+      end
+
+      test "orders, filters, limits, and pages messages", %{persistence: state} do
+        room = persist_room(state)
+        thread = persist_thread(state, room.id)
+        base = DateTime.from_unix!(1_700_000_000)
+
+        messages =
+          for offset <- 1..5 do
+            message =
+              contract_message(room.id, "message-#{offset}-#{unique_id("id")}", "sender",
+                thread_id: if(offset <= 3, do: thread.id),
+                inserted_at: DateTime.add(base, offset, :second)
+              )
+
+            assert {:ok, ^message} = @persistence_adapter.save_message(state, message)
+            message
+          end
+
+        assert {:ok, listed} = @persistence_adapter.get_messages(state, room.id, limit: 3)
+        assert Enum.map(listed, & &1.id) == messages |> Enum.drop(2) |> Enum.map(& &1.id)
+
+        assert {:ok, threaded} =
+                 @persistence_adapter.get_messages(state, room.id,
+                   thread_id: thread.id,
+                   limit: 10
+                 )
+
+        assert Enum.map(threaded, & &1.id) == messages |> Enum.take(3) |> Enum.map(& &1.id)
+
+        assert {:ok, before} =
+                 @persistence_adapter.get_messages(state, room.id,
+                   before: Enum.at(messages, 3).id,
+                   limit: 10
+                 )
+
+        assert Enum.map(before, & &1.id) == messages |> Enum.take(3) |> Enum.map(& &1.id)
+
+        assert {:ok, after_page} =
+                 @persistence_adapter.get_messages(state, room.id,
+                   after: Enum.at(messages, 1).id,
+                   limit: 10
+                 )
+
+        assert Enum.map(after_page, & &1.id) == messages |> Enum.drop(2) |> Enum.map(& &1.id)
+      end
+
+      test "room deletion clears child records and external indexes", %{persistence: state} do
+        room = persist_room(state)
+        thread = persist_thread(state, room.id)
+
+        message =
+          contract_message(room.id, unique_id("message"), "sender",
+            thread_id: thread.id,
+            external_id: unique_id("external-message"),
+            metadata: %{channel: :slack, bridge_id: "contract-bridge"}
+          )
+
+        assert {:ok, ^message} = @persistence_adapter.save_message(state, message)
+
+        assert {:ok, binding} =
+                 @persistence_adapter.create_room_binding(
+                   state,
+                   room.id,
+                   :slack,
+                   "contract-bridge",
+                   unique_id("external-room"),
+                   %{}
+                 )
+
+        assert :ok = @persistence_adapter.delete_room(state, room.id)
+        assert {:error, :not_found} = @persistence_adapter.get_room(state, room.id)
+        assert {:error, :not_found} = @persistence_adapter.get_thread(state, thread.id)
+        assert {:error, :not_found} = @persistence_adapter.get_message(state, message.id)
+
+        assert {:error, :not_found} =
+                 @persistence_adapter.get_message_by_external_id(
+                   state,
+                   :slack,
+                   "contract-bridge",
+                   message.external_id
+                 )
+
+        assert {:ok, []} = @persistence_adapter.list_room_bindings(state, room.id)
+        assert {:error, :not_found} = @persistence_adapter.delete_room_binding(state, binding.id)
+      end
+
+      test "external message index follows an updated external id", %{persistence: state} do
+        room = persist_room(state)
+        old_id = unique_id("old-external-message")
+        new_id = unique_id("new-external-message")
+
+        message =
+          contract_message(room.id, unique_id("message"), "sender",
+            external_id: old_id,
+            metadata: %{channel: :slack, bridge_id: "contract-bridge"}
+          )
+
+        assert {:ok, ^message} = @persistence_adapter.save_message(state, message)
+        assert {:ok, updated} = @persistence_adapter.update_message_external_id(state, message.id, new_id)
+        assert updated.external_id == new_id
+
+        assert {:error, :not_found} =
+                 @persistence_adapter.get_message_by_external_id(
+                   state,
+                   :slack,
+                   "contract-bridge",
+                   old_id
+                 )
+
+        assert {:ok, ^updated} =
+                 @persistence_adapter.get_message_by_external_id(
+                   state,
+                   :slack,
+                   "contract-bridge",
+                   new_id
+                 )
+      end
+
+      test "concurrent get-or-create returns one external room binding", %{persistence: state} do
+        external_id = unique_id("external-room")
+
+        results =
+          1..12
+          |> Task.async_stream(
+            fn _index ->
+              @persistence_adapter.get_or_create_room_by_external_binding(
+                state,
+                :slack,
+                "contract-bridge",
+                external_id,
+                %{type: :channel, name: "Concurrent contract room"}
+              )
+            end,
+            max_concurrency: 12,
+            ordered: false,
+            timeout: 10_000
+          )
+          |> Enum.map(fn {:ok, {:ok, room}} -> room end)
+
+        assert results |> Enum.map(& &1.id) |> Enum.uniq() |> length() == 1
+
+        assert {:ok, room} =
+                 @persistence_adapter.get_room_by_external_binding(
+                   state,
+                   :slack,
+                   "contract-bridge",
+                   external_id
+                 )
+
+        assert {:ok, [binding]} = @persistence_adapter.list_room_bindings(state, room.id)
+        assert binding.external_room_id == external_id
+      end
+
+      defp persist_room(state) do
+        room = Room.new(%{id: unique_id("room"), type: :direct})
+        {:ok, ^room} = @persistence_adapter.save_room(state, room)
+        room
+      end
+
+      defp persist_thread(state, room_id) do
+        thread = Thread.new(%{id: unique_id("thread"), room_id: room_id})
+        {:ok, ^thread} = @persistence_adapter.save_thread(state, thread)
+        thread
+      end
+
+      defp contract_message(room_id, id, sender_id, opts \\ []) do
+        Message.new(%{
+          id: id,
+          room_id: room_id,
+          sender_id: sender_id,
+          role: :user,
+          content: [%{type: :text, text: id}],
+          thread_id: Keyword.get(opts, :thread_id),
+          external_id: Keyword.get(opts, :external_id),
+          metadata: Keyword.get(opts, :metadata, %{}),
+          inserted_at: Keyword.get(opts, :inserted_at, DateTime.utc_now())
+        })
+      end
+
+      defp unique_id(prefix) do
+        "#{prefix}-#{System.unique_integer([:positive, :monotonic])}"
+      end
+    end
+  end
+
+  @doc false
+  def start({module, function, arguments}) do
+    apply(module, function, arguments)
+  end
+
+  @doc false
+  def stop({module, function, arguments}, state) do
+    apply(module, function, [state | arguments])
+  end
+end

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -111,10 +111,13 @@ defmodule Jido.Messaging.Persistence.ETS do
   @impl true
   def delete_room(state, room_id) do
     true = :ets.delete(state.rooms, room_id)
-    # Also delete associated messages
+
     message_ids = :ets.lookup(state.room_messages, room_id) |> Enum.map(&elem(&1, 1))
-    Enum.each(message_ids, fn msg_id -> :ets.delete(state.messages, msg_id) end)
-    true = :ets.delete(state.room_messages, room_id)
+    Enum.each(message_ids, &delete_message(state, &1))
+
+    {:ok, bindings} = list_room_bindings(state, room_id)
+    Enum.each(bindings, &delete_room_binding(state, &1.id))
+
     delete_threads_for_room(state, room_id)
     :ok
   end
@@ -263,6 +266,7 @@ defmodule Jido.Messaging.Persistence.ETS do
   def delete_message(state, message_id) do
     case :ets.lookup(state.messages, message_id) do
       [{^message_id, message}] ->
+        delete_external_id_index(state, message)
         true = :ets.delete(state.messages, message_id)
         # Remove from room_messages index (bag table - need to delete specific object)
         true = :ets.delete_object(state.room_messages, {message.room_id, message_id})
@@ -371,6 +375,9 @@ defmodule Jido.Messaging.Persistence.ETS do
 
         case :ets.insert_new(state.room_bindings, {binding_key, room.id}) do
           true ->
+            {:ok, _binding} =
+              create_room_binding(state, room.id, channel, bridge_id, external_id, %{})
+
             {:ok, room}
 
           false ->
@@ -459,6 +466,7 @@ defmodule Jido.Messaging.Persistence.ETS do
         channel = get_in(message.metadata, [:channel])
         bridge_id = get_in(message.metadata, [:bridge_id])
 
+        delete_external_id_index(state, message)
         updated_message = %{message | external_id: external_id}
         true = :ets.insert(state.messages, {message_id, updated_message})
 
@@ -828,6 +836,20 @@ defmodule Jido.Messaging.Persistence.ETS do
   defp maybe_delete_thread_message(state, %Message{thread_id: thread_id, id: message_id})
        when is_binary(thread_id) do
     true = :ets.delete_object(state.thread_messages, {thread_id, message_id})
+    :ok
+  end
+
+  defp delete_external_id_index(_state, %Message{external_id: nil}), do: :ok
+
+  defp delete_external_id_index(state, %Message{} = message) do
+    channel = get_in(message.metadata, [:channel])
+    bridge_id = get_in(message.metadata, [:bridge_id])
+
+    if channel && bridge_id do
+      key = {channel, bridge_id, message.external_id}
+      true = :ets.delete_object(state.message_external_ids, {key, message.id})
+    end
+
     :ok
   end
 

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -538,7 +538,7 @@ defmodule Jido.Messaging.Persistence.ETS do
     case :ets.lookup(state.room_bindings_by_id, binding_id) do
       [{^binding_id, binding}] ->
         key = binding_key(binding.channel, binding.bridge_id, binding.external_room_id)
-        true = :ets.delete(state.room_bindings, key)
+        true = :ets.delete_object(state.room_bindings, {key, binding.room_id})
         true = :ets.delete(state.room_bindings_by_id, binding_id)
         true = :ets.delete_object(state.room_bindings_by_room, {binding.room_id, binding_id})
         :ok

--- a/test/jido_messaging/deliver_test.exs
+++ b/test/jido_messaging/deliver_test.exs
@@ -170,6 +170,9 @@ defmodule Jido.Messaging.DeliverTest do
     test "routes proactive send through room bindings and bridge config", %{original_message: orig} do
       {:ok, _bridge} = TestMessaging.put_bridge_config(%{id: "bridge_mock", adapter_module: MockChannel})
 
+      {:ok, existing_bindings} = TestMessaging.list_room_bindings(orig.room_id)
+      Enum.each(existing_bindings, &TestMessaging.delete_room_binding(&1.id))
+
       {:ok, _binding} =
         TestMessaging.create_room_binding(orig.room_id, :mock, "bridge_mock", "route_chat", %{direction: :both})
 

--- a/test/jido_messaging/persistence/conformance_test.exs
+++ b/test/jido_messaging/persistence/conformance_test.exs
@@ -1,0 +1,14 @@
+defmodule Jido.Messaging.Persistence.ETSConformanceTest do
+  use Jido.Messaging.Persistence.Conformance,
+    adapter: Jido.Messaging.Persistence.ETS,
+    factory: {Jido.Messaging.Test.PersistenceConformanceFactory, :start_ets, []},
+    cleanup: {Jido.Messaging.Test.PersistenceConformanceFactory, :stop_ets, []},
+    async: true
+end
+
+defmodule Jido.Messaging.Persistence.SQLiteConformanceTest do
+  use Jido.Messaging.Persistence.Conformance,
+    adapter: Jido.Messaging.Persistence.SQLite,
+    factory: {Jido.Messaging.Test.PersistenceConformanceFactory, :start_sqlite, []},
+    cleanup: {Jido.Messaging.Test.PersistenceConformanceFactory, :stop_sqlite, []}
+end

--- a/test/jido_messaging/persistence/ets_test.exs
+++ b/test/jido_messaging/persistence/ets_test.exs
@@ -294,6 +294,31 @@ defmodule Jido.Messaging.Persistence.ETSTest do
     end
   end
 
+  describe "room binding operations" do
+    test "deleting an old owner preserves the current external binding", %{state: state} do
+      first_room = persist_room!(state)
+      second_room = persist_room!(state)
+
+      assert {:ok, first_binding} =
+               ETS.create_room_binding(state, first_room.id, :slack, "workspace", "channel", %{})
+
+      assert {:ok, second_binding} =
+               ETS.create_room_binding(state, second_room.id, :slack, "workspace", "channel", %{})
+
+      assert {:ok, ^second_room} =
+               ETS.get_room_by_external_binding(state, :slack, "workspace", "channel")
+
+      assert :ok = ETS.delete_room(state, first_room.id)
+
+      assert {:ok, ^second_room} =
+               ETS.get_room_by_external_binding(state, :slack, "workspace", "channel")
+
+      assert {:error, :not_found} = ETS.get_room(state, first_room.id)
+      assert {:ok, [^second_binding]} = ETS.list_room_bindings(state, second_room.id)
+      assert {:error, :not_found} = ETS.delete_room_binding(state, first_binding.id)
+    end
+  end
+
   defp persist_room!(state) do
     room = Room.new(%{type: :direct})
     {:ok, room} = ETS.save_room(state, room)

--- a/test/support/persistence_conformance_factory.ex
+++ b/test/support/persistence_conformance_factory.ex
@@ -1,0 +1,23 @@
+defmodule Jido.Messaging.Test.PersistenceConformanceFactory do
+  @moduledoc false
+
+  alias Exqlite.Sqlite3
+  alias Jido.Messaging.Persistence.{ETS, SQLite}
+
+  def start_ets, do: ETS.init([])
+  def stop_ets(_state), do: :ok
+
+  def start_sqlite do
+    path = Path.join(System.tmp_dir!(), "jido-messaging-conformance-#{unique_id()}.sqlite3")
+    SQLite.init(path: path)
+  end
+
+  def stop_sqlite(state) do
+    :ok = Sqlite3.close(state.db)
+    File.rm(state.path)
+  end
+
+  defp unique_id do
+    System.unique_integer([:positive, :monotonic])
+  end
+end


### PR DESCRIPTION
## Summary

- publish a reusable `Jido.Messaging.Persistence.Conformance` ExUnit contract with adapter factory and cleanup MFAs
- run the contract against ETS and SQLite for CRUD, not-found results, isolation, ordering, filtering, limits, cursors, cascades, external-index updates, and concurrent room binding creation
- fix the ETS parity gaps exposed by the contract: stale external-message indexes, incomplete room cascades, missing normal binding records, and deletion of reassigned bindings

## Verification

- `mix test test/jido_messaging/persistence/conformance_test.exs test/jido_messaging/persistence/ets_test.exs` (29 passed)
- `mix test` (608 passed, 4 skipped, 13 excluded)
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix dialyzer` (0 errors)

Closes #50