### PR TITLE
feat(config): resolve bridge secrets at operation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,9 @@ Supported top-level keys:
 
 Use `config/demo.topology.example.yaml` as the starter template.
 For live bridge ingress with Telegram polling + Discord gateway, use
-`config/demo.topology.live.yaml` with `.env` values.
+`config/demo.topology.live.yaml` with `.env` values. The live script resolves
+the Telegram token from its environment reference at operation time. It does
+not put the token in the stored bridge configuration.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,45 @@ config :jido_chat_discord,
   discord_public_key: System.get_env("DISCORD_PUBLIC_KEY")
 ```
 
+### Durable Bridge Secret References
+
+Do not put tokens or passwords in `BridgeConfig.credentials`. Durable bridge
+configuration stores opaque references in `secret_refs`:
+
+```elixir
+{:ok, _bridge} =
+  MyApp.Messaging.put_bridge_config(%{
+    id: "telegram-main",
+    adapter_module: Jido.Chat.Telegram.Adapter,
+    secret_refs: %{token: "vault://chat/telegram-main/token"}
+  })
+```
+
+Configure a resolver. The resolver can use environment variables, application
+configuration, a vault, or another secret manager:
+
+```elixir
+defmodule MyApp.SecretResolver do
+  @behaviour Jido.Messaging.SecretResolver
+
+  @impl true
+  def resolve(reference, _context), do: MyApp.Vault.fetch(reference)
+end
+
+config MyApp.Messaging, secret_resolver: MyApp.SecretResolver
+```
+
+The runtime resolves each reference when an adapter operation starts. A secret
+rotation therefore does not change the bridge record. The operation receives
+the resolved values in its `:credentials` adapter option.
+
+Raw credentials are not accepted in new or updated bridge records. For an
+existing durable record, replace `credentials` with `secret_refs` before you
+enable the bridge. A legacy record with nonempty `credentials` returns
+`{:bridge_credentials_migration_required, bridge_id}`. A failed lookup returns
+`{:secret_resolution_failed, bridge_id, credential, category}` without the
+resolver error details.
+
 ### Ingress Wiring Pattern
 
 `jido_messaging` is now the shared ingress runtime:

--- a/config/demo.topology.live.yaml
+++ b/config/demo.topology.live.yaml
@@ -15,8 +15,8 @@ bridge_rooms:
     bridge_configs:
       - id: "${TELEGRAM_BRIDGE_ID:-telegram-main}"
         adapter_module: Elixir.Jido.Chat.Telegram.Adapter
-        credentials:
-          token: "${TELEGRAM_BOT_TOKEN}"
+        secret_refs:
+          token: "TELEGRAM_BOT_TOKEN"
         opts:
           ingress:
             mode: polling

--- a/lib/jido_messaging/bridge_config.ex
+++ b/lib/jido_messaging/bridge_config.ex
@@ -3,6 +3,10 @@ defmodule Jido.Messaging.BridgeConfig do
   Runtime-editable bridge configuration for adapter-backed ingress/egress.
 
   `BridgeConfig` is the control-plane definition for a single external adapter bridge.
+
+  `secret_refs` contains durable, opaque references. Resolved credentials are
+  never stored in this struct. The `credentials` field is kept for data-shape
+  compatibility and must stay empty.
   """
 
   alias Jido.Chat.Adapter
@@ -14,6 +18,7 @@ defmodule Jido.Messaging.BridgeConfig do
               id: Zoi.string(),
               adapter_module: Zoi.module(),
               credentials: Zoi.map() |> Zoi.default(%{}),
+              secret_refs: Zoi.map() |> Zoi.default(%{}),
               opts: Zoi.map() |> Zoi.default(%{}),
               enabled: Zoi.boolean() |> Zoi.default(true),
               capabilities: Zoi.map() |> Zoi.default(%{}),
@@ -45,7 +50,8 @@ defmodule Jido.Messaging.BridgeConfig do
     struct!(__MODULE__, %{
       id: Map.get(attrs, :id, generate_id()),
       adapter_module: adapter_module,
-      credentials: Map.get(attrs, :credentials, %{}),
+      credentials: %{},
+      secret_refs: Map.get(attrs, :secret_refs, %{}),
       opts: Map.get(attrs, :opts, %{}),
       enabled: Map.get(attrs, :enabled, true),
       capabilities: Map.get(attrs, :capabilities, Adapter.capabilities(adapter_module)),
@@ -76,6 +82,14 @@ defmodule Jido.Messaging.BridgeConfig do
     |> Keyword.put_new(:settings, config.opts)
   end
 
+  @doc "Checks that a bridge config has no resolved credentials."
+  @spec validate_for_storage(t()) :: :ok | {:error, {:bridge_credentials_migration_required, String.t()}}
+  def validate_for_storage(%__MODULE__{credentials: credentials}) when credentials in [%{}, nil], do: :ok
+
+  def validate_for_storage(%__MODULE__{id: id}) do
+    {:error, {:bridge_credentials_migration_required, id}}
+  end
+
   defp normalize_attrs(attrs) do
     attrs
     |> Enum.reduce(%{}, fn
@@ -96,6 +110,7 @@ defmodule Jido.Messaging.BridgeConfig do
   defp key_to_atom("id"), do: :id
   defp key_to_atom("adapter_module"), do: :adapter_module
   defp key_to_atom("credentials"), do: :credentials
+  defp key_to_atom("secret_refs"), do: :secret_refs
   defp key_to_atom("opts"), do: :opts
   defp key_to_atom("enabled"), do: :enabled
   defp key_to_atom("capabilities"), do: :capabilities

--- a/lib/jido_messaging/bridge_server.ex
+++ b/lib/jido_messaging/bridge_server.ex
@@ -7,7 +7,7 @@ defmodule Jido.Messaging.BridgeServer do
 
   use GenServer
 
-  alias Jido.Messaging.{AdapterBridge, BridgeConfig, BridgeStatus}
+  alias Jido.Messaging.{AdapterBridge, BridgeConfig, BridgeStatus, SecretResolver}
 
   @type state :: %{
           instance_module: module(),
@@ -146,16 +146,17 @@ defmodule Jido.Messaging.BridgeServer do
     settings = config.opts || %{}
     ingress = ingress_settings(settings)
 
-    opts = [
+    base_opts = [
       instance_module: instance_module,
       bridge_id: bridge_id,
-      bridge_config: config,
-      settings: settings,
       ingress: ingress,
       sink_mfa: {Jido.Messaging.IngressSink, :emit, [instance_module, bridge_id]}
     ]
 
-    AdapterBridge.listener_child_specs(config.adapter_module, bridge_id, opts)
+    with {:ok, adapter_opts} <-
+           SecretResolver.adapter_opts_for_config(instance_module, config, :listener_start, base_opts) do
+      AdapterBridge.listener_child_specs(config.adapter_module, bridge_id, adapter_opts)
+    end
   end
 
   defp start_listener_supervisor([]), do: {:ok, nil}

--- a/lib/jido_messaging/config_store.ex
+++ b/lib/jido_messaging/config_store.ex
@@ -156,6 +156,7 @@ defmodule Jido.Messaging.ConfigStore do
 
     reply =
       with :ok <- validate_revision(expected_revision, existing),
+           :ok <- validate_bridge_secrets(attrs, existing),
            {:ok, config} <- normalize_bridge_config(attrs, existing),
            {:ok, _saved} <- persistence.save_bridge_config(persistence_state, config) do
         trigger_reconcile(state.instance_module)
@@ -265,6 +266,22 @@ defmodule Jido.Messaging.ConfigStore do
       {:ok, config}
     else
       {:error, :invalid_adapter_module}
+    end
+  end
+
+  defp validate_bridge_secrets(attrs, existing) do
+    incoming_credentials = map_get(attrs, :credentials)
+    existing_credentials = existing && existing.credentials
+
+    cond do
+      is_map(incoming_credentials) and map_size(incoming_credentials) > 0 ->
+        {:error, :raw_bridge_credentials_not_allowed}
+
+      is_map(existing_credentials) and map_size(existing_credentials) > 0 ->
+        {:error, {:bridge_credentials_migration_required, existing.id}}
+
+      true ->
+        :ok
     end
   end
 
@@ -398,6 +415,7 @@ defmodule Jido.Messaging.ConfigStore do
   defp key_to_atom("adapter_module"), do: :adapter_module
   defp key_to_atom("adapter"), do: :adapter_module
   defp key_to_atom("credentials"), do: :credentials
+  defp key_to_atom("secret_refs"), do: :secret_refs
   defp key_to_atom("opts"), do: :opts
   defp key_to_atom("enabled"), do: :enabled
   defp key_to_atom("capabilities"), do: :capabilities

--- a/lib/jido_messaging/config_store.ex
+++ b/lib/jido_messaging/config_store.ex
@@ -271,6 +271,7 @@ defmodule Jido.Messaging.ConfigStore do
 
   defp validate_bridge_secrets(attrs, existing) do
     incoming_credentials = map_get(attrs, :credentials)
+    incoming_secret_refs = map_get(attrs, :secret_refs)
     existing_credentials = existing && existing.credentials
 
     cond do
@@ -278,11 +279,20 @@ defmodule Jido.Messaging.ConfigStore do
         {:error, :raw_bridge_credentials_not_allowed}
 
       is_map(existing_credentials) and map_size(existing_credentials) > 0 ->
-        {:error, {:bridge_credentials_migration_required, existing.id}}
+        if explicit_secret_migration?(attrs, incoming_credentials, incoming_secret_refs) do
+          :ok
+        else
+          {:error, {:bridge_credentials_migration_required, existing.id}}
+        end
 
       true ->
         :ok
     end
+  end
+
+  defp explicit_secret_migration?(attrs, credentials, secret_refs) do
+    Map.has_key?(attrs, :credentials) and credentials == %{} and
+      Map.has_key?(attrs, :secret_refs) and is_map(secret_refs) and map_size(secret_refs) > 0
   end
 
   defp normalize_routing_policy(attrs, existing) do

--- a/lib/jido_messaging/demo/topology.ex
+++ b/lib/jido_messaging/demo/topology.ex
@@ -432,6 +432,7 @@ defmodule Jido.Messaging.Demo.Topology do
   defp safe_key_to_atom("dedupe_scope"), do: :dedupe_scope
   defp safe_key_to_atom("fallback_order"), do: :fallback_order
   defp safe_key_to_atom("credentials"), do: :credentials
+  defp safe_key_to_atom("secret_refs"), do: :secret_refs
   defp safe_key_to_atom("opts"), do: :opts
   defp safe_key_to_atom("capabilities"), do: :capabilities
   defp safe_key_to_atom("revision"), do: :revision

--- a/lib/jido_messaging/inbound_router.ex
+++ b/lib/jido_messaging/inbound_router.ex
@@ -10,7 +10,7 @@ defmodule Jido.Messaging.InboundRouter do
 
   alias Jido.Chat
   alias Jido.Chat.{Adapter, EventEnvelope, Incoming, WebhookRequest, WebhookResponse}
-  alias Jido.Messaging.{BridgeConfig, BridgeServer, ConfigStore, Ingest, IngressOutcome}
+  alias Jido.Messaging.{BridgeConfig, BridgeServer, ConfigStore, Ingest, IngressOutcome, SecretResolver}
 
   @type ingest_result ::
           {:ok, {:message, Jido.Messaging.Message.t(), Ingest.context(), EventEnvelope.t()}}
@@ -85,8 +85,8 @@ defmodule Jido.Messaging.InboundRouter do
 
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
          :ok <- ensure_enabled(config),
-         {:ok, adapter_module} <- ensure_adapter_module(config) do
-      adapter_opts = BridgeConfig.adapter_opts(config, opts)
+         {:ok, adapter_module} <- ensure_adapter_module(config),
+         {:ok, adapter_opts} <- SecretResolver.adapter_opts_for_config(instance_module, config, :webhook, opts) do
       request = build_webhook_request(adapter_module, payload, request_meta)
       format_opts = Keyword.put(adapter_opts, :request, request)
 
@@ -118,9 +118,8 @@ defmodule Jido.Messaging.InboundRouter do
 
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
          :ok <- ensure_enabled(config),
-         {:ok, adapter_module} <- ensure_adapter_module(config) do
-      adapter_opts = BridgeConfig.adapter_opts(config, opts)
-
+         {:ok, adapter_module} <- ensure_adapter_module(config),
+         {:ok, adapter_opts} <- SecretResolver.adapter_opts_for_config(instance_module, config, :payload, opts) do
       outcome =
         case normalize_payload_event(adapter_module, payload, adapter_opts) do
           {:ok, :noop} ->

--- a/lib/jido_messaging/ingress_subscriptions.ex
+++ b/lib/jido_messaging/ingress_subscriptions.ex
@@ -6,7 +6,7 @@ defmodule Jido.Messaging.IngressSubscriptions do
   messaging runtime control plane. It does not own webhook request routing.
   """
 
-  alias Jido.Messaging.{AdapterBridge, BridgeConfig, ConfigStore, IngressSubscription}
+  alias Jido.Messaging.{AdapterBridge, BridgeConfig, ConfigStore, IngressSubscription, SecretResolver}
 
   @type result :: {:ok, IngressSubscription.t()} | {:error, term()}
   @type list_result :: {:ok, [IngressSubscription.t()]} | {:error, term()}
@@ -17,9 +17,9 @@ defmodule Jido.Messaging.IngressSubscriptions do
       when is_atom(instance_module) and is_binary(bridge_id) and is_list(opts) do
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
          :ok <- ensure_enabled(config),
-         {:ok, adapter_module} <- ensure_adapter_module(config) do
+         {:ok, adapter_module} <- ensure_adapter_module(config),
+         {:ok, adapter_opts} <- subscription_opts(instance_module, bridge_id, config, :subscription_ensure, opts) do
       adapter_name = AdapterBridge.channel_type(adapter_module)
-      adapter_opts = subscription_opts(instance_module, bridge_id, config, opts)
 
       case AdapterBridge.ensure_ingress_subscription(adapter_module, bridge_id, adapter_opts) do
         {:ok, raw_subscription} ->
@@ -40,9 +40,9 @@ defmodule Jido.Messaging.IngressSubscriptions do
   def list(instance_module, bridge_id, opts \\ [])
       when is_atom(instance_module) and is_binary(bridge_id) and is_list(opts) do
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
-         {:ok, adapter_module} <- ensure_adapter_module(config) do
+         {:ok, adapter_module} <- ensure_adapter_module(config),
+         {:ok, adapter_opts} <- subscription_opts(instance_module, bridge_id, config, :subscription_list, opts) do
       adapter_name = AdapterBridge.channel_type(adapter_module)
-      adapter_opts = subscription_opts(instance_module, bridge_id, config, opts)
 
       case AdapterBridge.list_ingress_subscriptions(adapter_module, bridge_id, adapter_opts) do
         {:ok, raw_subscriptions} ->
@@ -67,9 +67,9 @@ defmodule Jido.Messaging.IngressSubscriptions do
   def delete(instance_module, bridge_id, subscription_id, opts \\ [])
       when is_atom(instance_module) and is_binary(bridge_id) and is_binary(subscription_id) and is_list(opts) do
     with {:ok, config} <- fetch_bridge(instance_module, bridge_id),
-         {:ok, adapter_module} <- ensure_adapter_module(config) do
+         {:ok, adapter_module} <- ensure_adapter_module(config),
+         {:ok, adapter_opts} <- subscription_opts(instance_module, bridge_id, config, :subscription_delete, opts) do
       adapter_name = AdapterBridge.channel_type(adapter_module)
-      adapter_opts = subscription_opts(instance_module, bridge_id, config, opts)
 
       case AdapterBridge.delete_ingress_subscription(adapter_module, bridge_id, subscription_id, adapter_opts) do
         {:ok, raw_subscription} ->
@@ -107,21 +107,21 @@ defmodule Jido.Messaging.IngressSubscriptions do
     end
   end
 
-  defp subscription_opts(instance_module, bridge_id, %BridgeConfig{} = config, opts) do
+  defp subscription_opts(instance_module, bridge_id, %BridgeConfig{} = config, operation, opts) do
     settings = config.opts
     ingress = ingress_settings(settings)
     target_url = target_url(opts, ingress)
 
-    opts
-    |> Keyword.put_new(:instance_module, instance_module)
-    |> Keyword.put_new(:bridge_id, bridge_id)
-    |> Keyword.put_new(:bridge_config, config)
-    |> Keyword.put_new(:credentials, config.credentials)
-    |> Keyword.put_new(:settings, settings)
-    |> Keyword.put_new(:ingress, ingress)
-    |> Keyword.put_new(:adapter_name, AdapterBridge.channel_type(config.adapter_module))
-    |> maybe_put_new(:target_url, target_url)
-    |> maybe_put_new(:webhook_url, target_url)
+    base_opts =
+      opts
+      |> Keyword.put_new(:instance_module, instance_module)
+      |> Keyword.put_new(:bridge_id, bridge_id)
+      |> Keyword.put_new(:ingress, ingress)
+      |> Keyword.put_new(:adapter_name, AdapterBridge.channel_type(config.adapter_module))
+      |> maybe_put_new(:target_url, target_url)
+      |> maybe_put_new(:webhook_url, target_url)
+
+    SecretResolver.adapter_opts_for_config(instance_module, config, operation, base_opts)
   end
 
   defp ingress_settings(settings) when is_map(settings) do

--- a/lib/jido_messaging/outbound_gateway.ex
+++ b/lib/jido_messaging/outbound_gateway.ex
@@ -199,6 +199,7 @@ defmodule Jido.Messaging.OutboundGateway do
   def classify_error({:unsupported_operation, _}), do: :fatal
   def classify_error({:unsupported_media, _kind, _causes}), do: :terminal
   def classify_error({:media_policy_denied, _reason}), do: :terminal
+  def classify_error({:secret_resolution_failed, _bridge_id, _credential, _category}), do: :terminal
 
   def classify_error(reason) do
     case AdapterBridge.classify_failure(reason) do

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -15,6 +15,7 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   alias Jido.Messaging.MediaPolicy
   alias Jido.Messaging.OutboundGateway
   alias Jido.Messaging.Security
+  alias Jido.Messaging.SecretResolver
 
   @default_call_timeout 15_000
 
@@ -400,7 +401,12 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   defp adapter_opts(instance_module, request) do
     case ConfigStore.get_bridge_config(instance_module, request.bridge_id) do
       {:ok, %BridgeConfig{adapter_module: adapter_module} = config} when adapter_module == request.channel ->
-        {:ok, BridgeConfig.adapter_opts(config, request.opts)}
+        SecretResolver.adapter_opts_for_config(
+          instance_module,
+          config,
+          request.operation,
+          request.opts
+        )
 
       {:ok, %BridgeConfig{adapter_module: adapter_module}} ->
         {:error, {:bridge_adapter_mismatch, request.bridge_id, adapter_module, request.channel}}

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -9,8 +9,6 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   @dialyzer {:nowarn_function, media_text_fallback: 3}
 
   alias Jido.Messaging.AdapterBridge
-  alias Jido.Messaging.BridgeConfig
-  alias Jido.Messaging.ConfigStore
   alias Jido.Messaging.DeadLetter
   alias Jido.Messaging.MediaPolicy
   alias Jido.Messaging.OutboundGateway
@@ -399,21 +397,13 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
   end
 
   defp adapter_opts(instance_module, request) do
-    case ConfigStore.get_bridge_config(instance_module, request.bridge_id) do
-      {:ok, %BridgeConfig{adapter_module: adapter_module} = config} when adapter_module == request.channel ->
-        SecretResolver.adapter_opts_for_config(
-          instance_module,
-          config,
-          request.operation,
-          request.opts
-        )
-
-      {:ok, %BridgeConfig{adapter_module: adapter_module}} ->
-        {:error, {:bridge_adapter_mismatch, request.bridge_id, adapter_module, request.channel}}
-
-      {:error, :not_found} ->
-        {:ok, request.opts}
-    end
+    SecretResolver.adapter_opts(
+      instance_module,
+      request.bridge_id,
+      request.channel,
+      request.operation,
+      request.opts
+    )
   end
 
   defp media_preflight(request) do

--- a/lib/jido_messaging/outbound_gateway/partition.ex
+++ b/lib/jido_messaging/outbound_gateway/partition.ex
@@ -476,8 +476,6 @@ defmodule Jido.Messaging.OutboundGateway.Partition do
     end
   end
 
-  defp media_policy_opts(_opts), do: []
-
   defp invoke_channel(fun) when is_function(fun, 0) do
     try do
       case fun.() do

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -63,7 +63,7 @@ defmodule Jido.Messaging.Persistence.ETS do
   def schema, do: @schema
 
   alias Jido.Chat.{Participant, Room}
-  alias Jido.Messaging.{IngressSubscription, Message, RoomBinding, Thread}
+  alias Jido.Messaging.{BridgeConfig, IngressSubscription, Message, RoomBinding, Thread}
 
   @impl true
   def init(_opts) do
@@ -605,9 +605,11 @@ defmodule Jido.Messaging.Persistence.ETS do
   # Bridge/routing control plane persistence
 
   @impl true
-  def save_bridge_config(state, bridge_config) do
-    true = :ets.insert(state.bridge_configs, {bridge_config.id, bridge_config})
-    {:ok, bridge_config}
+  def save_bridge_config(state, %BridgeConfig{} = bridge_config) do
+    with :ok <- BridgeConfig.validate_for_storage(bridge_config) do
+      true = :ets.insert(state.bridge_configs, {bridge_config.id, bridge_config})
+      {:ok, bridge_config}
+    end
   end
 
   @impl true

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -477,7 +477,9 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   @impl true
   def save_bridge_config(state, %BridgeConfig{} = bridge_config) do
-    persist(state, "bridge_config", bridge_config.id, bridge_config, inserted_at: bridge_config.inserted_at)
+    with :ok <- BridgeConfig.validate_for_storage(bridge_config) do
+      persist(state, "bridge_config", bridge_config.id, bridge_config, inserted_at: bridge_config.inserted_at)
+    end
   end
 
   @impl true

--- a/lib/jido_messaging/secret_resolver.ex
+++ b/lib/jido_messaging/secret_resolver.ex
@@ -44,9 +44,23 @@ defmodule Jido.Messaging.SecretResolver do
   @spec adapter_opts(module(), String.t(), atom(), keyword()) :: {:ok, keyword()} | {:error, failure() | term()}
   def adapter_opts(instance_module, bridge_id, operation, opts \\ [])
       when is_atom(instance_module) and is_binary(bridge_id) and is_atom(operation) and is_list(opts) do
+    adapter_opts(instance_module, bridge_id, nil, operation, opts)
+  end
+
+  @doc "Adds operation-scoped credentials after checking the requested adapter."
+  @spec adapter_opts(module(), String.t(), module(), atom(), keyword()) ::
+          {:ok, keyword()} | {:error, failure() | term()}
+  def adapter_opts(instance_module, bridge_id, adapter_module, operation, opts)
+      when is_atom(instance_module) and is_binary(bridge_id) and
+             (is_atom(adapter_module) or is_nil(adapter_module)) and is_atom(operation) and is_list(opts) do
     case ConfigStore.get_bridge_config(instance_module, bridge_id) do
-      {:ok, %BridgeConfig{} = config} -> adapter_opts_for_config(instance_module, config, operation, opts)
-      {:error, :not_found} -> {:ok, opts}
+      {:ok, %BridgeConfig{} = config} ->
+        with :ok <- validate_adapter(config, adapter_module) do
+          adapter_opts_for_config(instance_module, config, operation, opts)
+        end
+
+      {:error, :not_found} ->
+        {:ok, opts}
     end
   end
 
@@ -70,7 +84,7 @@ defmodule Jido.Messaging.SecretResolver do
           {:ok, map()} | {:error, failure() | term()}
   def resolve_credentials(instance_module, %BridgeConfig{} = config, operation)
       when is_atom(instance_module) and is_atom(operation) do
-    refs = config.secret_refs || %{}
+    refs = Map.get(config, :secret_refs, %{}) || %{}
 
     if map_size(refs) == 0 do
       {:ok, %{}}
@@ -103,6 +117,14 @@ defmodule Jido.Messaging.SecretResolver do
   defp configured_resolver(instance_module) do
     Application.get_env(instance_module, :secret_resolver) ||
       Application.get_env(:jido_messaging, :secret_resolver)
+  end
+
+  defp validate_adapter(_config, nil), do: :ok
+
+  defp validate_adapter(%BridgeConfig{adapter_module: adapter_module}, adapter_module), do: :ok
+
+  defp validate_adapter(%BridgeConfig{} = config, adapter_module) do
+    {:error, {:bridge_adapter_mismatch, config.id, config.adapter_module, adapter_module}}
   end
 
   defp resolve_one(nil, _reference, _context), do: {:error, :resolver_not_configured}

--- a/lib/jido_messaging/secret_resolver.ex
+++ b/lib/jido_messaging/secret_resolver.ex
@@ -47,7 +47,6 @@ defmodule Jido.Messaging.SecretResolver do
     case ConfigStore.get_bridge_config(instance_module, bridge_id) do
       {:ok, %BridgeConfig{} = config} -> adapter_opts_for_config(instance_module, config, operation, opts)
       {:error, :not_found} -> {:ok, opts}
-      {:error, _reason} = error -> error
     end
   end
 
@@ -62,7 +61,7 @@ defmodule Jido.Messaging.SecretResolver do
        opts
        |> Keyword.put(:bridge_config, config)
        |> Keyword.put(:credentials, credentials)
-       |> Keyword.put(:settings, config.opts || %{})}
+       |> Keyword.put(:settings, config.opts)}
     end
   end
 

--- a/lib/jido_messaging/secret_resolver.ex
+++ b/lib/jido_messaging/secret_resolver.ex
@@ -1,0 +1,131 @@
+defmodule Jido.Messaging.SecretResolver do
+  @moduledoc """
+  Resolves durable bridge secret references at an adapter operation boundary.
+
+  Configure a resolver globally or for one messaging module:
+
+      config :jido_messaging, secret_resolver: MyApp.SecretResolver
+      config MyApp.Messaging, secret_resolver: MyApp.SecretResolver
+
+  A resolver receives the opaque stored reference and safe operation context:
+
+      defmodule MyApp.SecretResolver do
+        @behaviour Jido.Messaging.SecretResolver
+
+        @impl true
+        def resolve(reference, context) do
+          MySecretManager.fetch(reference, context)
+        end
+      end
+
+  The resolved value exists only in the adapter options for the current
+  operation. Resolver error details are reduced to a classified reason so a
+  provider cannot put a secret in diagnostics.
+  """
+
+  alias Jido.Messaging.{BridgeConfig, ConfigStore}
+
+  @type secret_reference :: term()
+  @type context :: %{
+          required(:instance_module) => module(),
+          required(:bridge_id) => String.t(),
+          required(:adapter_module) => module(),
+          required(:operation) => atom(),
+          required(:credential) => atom() | String.t()
+        }
+  @type failure_category ::
+          :resolver_not_configured | :not_found | :resolver_failed | :invalid_resolver_response
+  @type failure ::
+          {:secret_resolution_failed, String.t(), atom() | String.t(), failure_category()}
+
+  @callback resolve(secret_reference(), context()) :: {:ok, term()} | {:error, term()}
+
+  @doc "Adds operation-scoped credentials and bridge settings to adapter options."
+  @spec adapter_opts(module(), String.t(), atom(), keyword()) :: {:ok, keyword()} | {:error, failure() | term()}
+  def adapter_opts(instance_module, bridge_id, operation, opts \\ [])
+      when is_atom(instance_module) and is_binary(bridge_id) and is_atom(operation) and is_list(opts) do
+    case ConfigStore.get_bridge_config(instance_module, bridge_id) do
+      {:ok, %BridgeConfig{} = config} -> adapter_opts_for_config(instance_module, config, operation, opts)
+      {:error, :not_found} -> {:ok, opts}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc "Adds credentials from a fetched bridge config to adapter options."
+  @spec adapter_opts_for_config(module(), BridgeConfig.t(), atom(), keyword()) ::
+          {:ok, keyword()} | {:error, failure() | term()}
+  def adapter_opts_for_config(instance_module, %BridgeConfig{} = config, operation, opts)
+      when is_atom(instance_module) and is_atom(operation) and is_list(opts) do
+    with :ok <- BridgeConfig.validate_for_storage(config),
+         {:ok, credentials} <- resolve_credentials(instance_module, config, operation) do
+      {:ok,
+       opts
+       |> Keyword.put(:bridge_config, config)
+       |> Keyword.put(:credentials, credentials)
+       |> Keyword.put(:settings, config.opts || %{})}
+    end
+  end
+
+  @doc "Resolves all credential references for one bridge operation."
+  @spec resolve_credentials(module(), BridgeConfig.t(), atom()) ::
+          {:ok, map()} | {:error, failure() | term()}
+  def resolve_credentials(instance_module, %BridgeConfig{} = config, operation)
+      when is_atom(instance_module) and is_atom(operation) do
+    refs = config.secret_refs || %{}
+
+    if map_size(refs) == 0 do
+      {:ok, %{}}
+    else
+      resolve_references(instance_module, config, operation, refs)
+    end
+  end
+
+  defp resolve_references(instance_module, config, operation, refs) do
+    resolver = configured_resolver(instance_module)
+
+    refs
+    |> Enum.sort_by(fn {credential, _reference} -> to_string(credential) end)
+    |> Enum.reduce_while({:ok, %{}}, fn {credential, reference}, {:ok, credentials} ->
+      context = %{
+        instance_module: instance_module,
+        bridge_id: config.id,
+        adapter_module: config.adapter_module,
+        operation: operation,
+        credential: credential
+      }
+
+      case resolve_one(resolver, reference, context) do
+        {:ok, value} -> {:cont, {:ok, Map.put(credentials, credential, value)}}
+        {:error, category} -> {:halt, {:error, failure(config.id, credential, category)}}
+      end
+    end)
+  end
+
+  defp configured_resolver(instance_module) do
+    Application.get_env(instance_module, :secret_resolver) ||
+      Application.get_env(:jido_messaging, :secret_resolver)
+  end
+
+  defp resolve_one(nil, _reference, _context), do: {:error, :resolver_not_configured}
+
+  defp resolve_one(resolver, reference, context) when is_atom(resolver) do
+    try do
+      case resolver.resolve(reference, context) do
+        {:ok, value} -> {:ok, value}
+        {:error, :not_found} -> {:error, :not_found}
+        {:error, _reason} -> {:error, :resolver_failed}
+        _other -> {:error, :invalid_resolver_response}
+      end
+    rescue
+      _exception -> {:error, :resolver_failed}
+    catch
+      _kind, _reason -> {:error, :resolver_failed}
+    end
+  end
+
+  defp resolve_one(_resolver, _reference, _context), do: {:error, :resolver_not_configured}
+
+  defp failure(bridge_id, credential, category) do
+    {:secret_resolution_failed, bridge_id, credential, category}
+  end
+end

--- a/scripts/demo_bridge_live.exs
+++ b/scripts/demo_bridge_live.exs
@@ -10,6 +10,21 @@ Mix.install([
   {:jido_messaging, path: jido_messaging_path}
 ])
 
+defmodule Jido.Messaging.Demo.EnvSecretResolver do
+  @behaviour Jido.Messaging.SecretResolver
+
+  @impl true
+  def resolve(environment_variable, _context) when is_binary(environment_variable) do
+    System.fetch_env(environment_variable)
+  end
+end
+
+Application.put_env(
+  :jido_messaging,
+  :secret_resolver,
+  Jido.Messaging.Demo.EnvSecretResolver
+)
+
 File.cd!(jido_messaging_path, fn ->
   Mix.Task.run("jido.messaging.demo", ["--topology", "config/demo.topology.live.yaml"])
 end)

--- a/test/jido_messaging/inbound_router_test.exs
+++ b/test/jido_messaging/inbound_router_test.exs
@@ -118,11 +118,29 @@ defmodule Jido.Messaging.InboundRouterTest do
     end
   end
 
+  defmodule BridgeSecretResolver do
+    @behaviour Jido.Messaging.SecretResolver
+
+    @impl true
+    def resolve(:bridge_secret, _context), do: {:ok, "bridge-secret"}
+  end
+
   defmodule TestMessaging do
     use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
   end
 
   setup do
+    original_resolver = Application.get_env(TestMessaging, :secret_resolver)
+    Application.put_env(TestMessaging, :secret_resolver, BridgeSecretResolver)
+
+    on_exit(fn ->
+      if is_nil(original_resolver) do
+        Application.delete_env(TestMessaging, :secret_resolver)
+      else
+        Application.put_env(TestMessaging, :secret_resolver, original_resolver)
+      end
+    end)
+
     start_supervised!(TestMessaging)
     {:ok, _bridge} = TestMessaging.put_bridge_config(%{id: "bridge_tg", adapter_module: RouterAdapter})
     :ok
@@ -191,7 +209,7 @@ defmodule Jido.Messaging.InboundRouterTest do
         TestMessaging.put_bridge_config(%{
           id: "bridge_config_aware",
           adapter_module: ConfigAwareAdapter,
-          credentials: %{token: "bridge-secret"},
+          secret_refs: %{token: :bridge_secret},
           opts: %{parse_result: :noop}
         })
 

--- a/test/jido_messaging/outbound_gateway_test.exs
+++ b/test/jido_messaging/outbound_gateway_test.exs
@@ -103,6 +103,15 @@ defmodule Jido.Messaging.OutboundGatewayTest do
     end
   end
 
+  defmodule BridgeSecretResolver do
+    @behaviour Jido.Messaging.SecretResolver
+
+    @impl true
+    def resolve(:bridge_token, _context), do: {:ok, "bridge-token"}
+    def resolve(:stored_token, _context), do: {:ok, "stored-token"}
+    def resolve(:must_not_resolve, _context), do: raise("adapter mismatch resolved a secret")
+  end
+
   defmodule MediaChannel do
     @behaviour Jido.Chat.Adapter
 
@@ -144,12 +153,20 @@ defmodule Jido.Messaging.OutboundGatewayTest do
 
   setup do
     original_config = Application.get_env(TestMessaging, :outbound_gateway)
+    original_resolver = Application.get_env(TestMessaging, :secret_resolver)
+    Application.put_env(TestMessaging, :secret_resolver, BridgeSecretResolver)
 
     on_exit(fn ->
       if is_nil(original_config) do
         Application.delete_env(TestMessaging, :outbound_gateway)
       else
         Application.put_env(TestMessaging, :outbound_gateway, original_config)
+      end
+
+      if is_nil(original_resolver) do
+        Application.delete_env(TestMessaging, :secret_resolver)
+      else
+        Application.put_env(TestMessaging, :secret_resolver, original_resolver)
       end
     end)
 
@@ -494,7 +511,7 @@ defmodule Jido.Messaging.OutboundGatewayTest do
         TestMessaging.put_bridge_config(%{
           id: "config_bridge",
           adapter_module: BridgeConfigChannel,
-          credentials: %{token: "bridge-token"},
+          secret_refs: %{token: :bridge_token},
           opts: %{tenant: "tenant-one"}
         })
 
@@ -509,18 +526,18 @@ defmodule Jido.Messaging.OutboundGatewayTest do
 
       assert_receive {:bridge_adapter_opts, adapter_opts}
       assert adapter_opts[:bridge_config] == bridge_config
-      assert adapter_opts[:credentials] == bridge_config.credentials
+      assert adapter_opts[:credentials] == %{token: "bridge-token"}
       assert adapter_opts[:settings] == bridge_config.opts
     end
 
-    test "call-specific adapter options override bridge defaults" do
+    test "resolved credentials replace call-specific credential values" do
       start_messaging(partition_count: 1, queue_capacity: 8, max_attempts: 1)
 
       {:ok, _bridge_config} =
         TestMessaging.put_bridge_config(%{
           id: "override_bridge",
           adapter_module: BridgeConfigChannel,
-          credentials: %{token: "stored-token"},
+          secret_refs: %{token: :stored_token},
           opts: %{tenant: "stored-tenant"}
         })
 
@@ -537,7 +554,7 @@ defmodule Jido.Messaging.OutboundGatewayTest do
                )
 
       assert_receive {:bridge_adapter_opts, adapter_opts}
-      assert adapter_opts[:credentials] == %{token: "override-token"}
+      assert adapter_opts[:credentials] == %{token: "stored-token"}
       assert adapter_opts[:settings] == %{tenant: "stored-tenant"}
     end
 
@@ -548,7 +565,7 @@ defmodule Jido.Messaging.OutboundGatewayTest do
                TestMessaging.put_bridge_config(%{
                  id: "mismatch_bridge",
                  adapter_module: BridgeConfigChannel,
-                 credentials: %{token: "must-not-leak"}
+                 secret_refs: %{token: :must_not_resolve}
                })
 
       context = %{

--- a/test/jido_messaging/secret_resolver_test.exs
+++ b/test/jido_messaging/secret_resolver_test.exs
@@ -1,0 +1,164 @@
+defmodule Jido.Messaging.SecretResolverTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.Messaging.OutboundGateway
+
+  @marker "secret-marker-do-not-persist"
+
+  defmodule Resolver do
+    @behaviour Jido.Messaging.SecretResolver
+
+    @impl true
+    def resolve(:failing_reference, _context) do
+      {:error, {:provider_failure, "secret-marker-do-not-persist"}}
+    end
+
+    def resolve(reference, _context) do
+      Application.fetch_env(__MODULE__, reference)
+    end
+  end
+
+  defmodule Adapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :secret_test
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, text, opts) do
+      if test_pid = Keyword.get(opts, :test_pid) do
+        send(test_pid, {:adapter_credentials, text, Keyword.fetch!(opts, :credentials)})
+      end
+
+      {:ok, %{message_id: "secret-test-#{text}"}}
+    end
+  end
+
+  defmodule ETSMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
+  end
+
+  defmodule SQLiteMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.SQLite
+  end
+
+  setup do
+    original_ets_resolver = Application.get_env(ETSMessaging, :secret_resolver)
+    original_sqlite_resolver = Application.get_env(SQLiteMessaging, :secret_resolver)
+    original_secret = Application.get_env(Resolver, :telegram_token)
+
+    Application.put_env(ETSMessaging, :secret_resolver, Resolver)
+    Application.put_env(SQLiteMessaging, :secret_resolver, Resolver)
+
+    on_exit(fn ->
+      restore_env(ETSMessaging, :secret_resolver, original_ets_resolver)
+      restore_env(SQLiteMessaging, :secret_resolver, original_sqlite_resolver)
+      restore_env(Resolver, :telegram_token, original_secret)
+    end)
+
+    :ok
+  end
+
+  test "resolves secrets for each outbound operation and observes rotation" do
+    start_supervised!(ETSMessaging)
+    Application.put_env(Resolver, :telegram_token, @marker)
+
+    assert {:ok, stored} =
+             ETSMessaging.put_bridge_config(%{
+               id: "secret-rotation",
+               adapter_module: Adapter,
+               secret_refs: %{token: :telegram_token}
+             })
+
+    assert stored.credentials == %{}
+    assert stored.secret_refs == %{token: :telegram_token}
+    refute inspect(stored) =~ @marker
+
+    context = %{channel: Adapter, bridge_id: stored.id, external_room_id: "room-1"}
+
+    assert {:ok, _result} =
+             OutboundGateway.send_message(ETSMessaging, context, "first", test_pid: self())
+
+    assert_receive {:adapter_credentials, "first", %{token: @marker}}
+
+    rotated = "rotated-secret-marker"
+    Application.put_env(Resolver, :telegram_token, rotated)
+
+    assert {:ok, _result} =
+             OutboundGateway.send_message(ETSMessaging, context, "second", test_pid: self())
+
+    assert_receive {:adapter_credentials, "second", %{token: ^rotated}}
+
+    assert {:ok, fetched} = ETSMessaging.get_bridge_config(stored.id)
+    assert fetched.secret_refs == stored.secret_refs
+    assert fetched.credentials == %{}
+  end
+
+  test "rejects raw bridge credentials" do
+    start_supervised!(ETSMessaging)
+
+    assert {:error, :raw_bridge_credentials_not_allowed} =
+             ETSMessaging.put_bridge_config(%{
+               id: "raw-secret",
+               adapter_module: Adapter,
+               credentials: %{token: @marker}
+             })
+  end
+
+  test "classifies resolver failures without diagnostic secret values" do
+    start_supervised!(ETSMessaging)
+
+    assert {:ok, stored} =
+             ETSMessaging.put_bridge_config(%{
+               id: "secret-failure",
+               adapter_module: Adapter,
+               secret_refs: %{token: :failing_reference}
+             })
+
+    context = %{channel: Adapter, bridge_id: stored.id, external_room_id: "room-1"}
+
+    log =
+      capture_log(fn ->
+        assert {:error, error} =
+                 OutboundGateway.send_message(ETSMessaging, context, "failure", test_pid: self())
+
+        assert error.reason ==
+                 {:secret_resolution_failed, "secret-failure", :token, :resolver_failed}
+
+        assert error.category == :terminal
+        refute inspect(error) =~ @marker
+      end)
+
+    refute log =~ @marker
+  end
+
+  test "SQLite stores references without resolved marker values" do
+    path = Path.join(System.tmp_dir!(), "jido-messaging-secrets-#{System.unique_integer([:positive])}.sqlite3")
+    File.rm(path)
+
+    start_supervised!({SQLiteMessaging, persistence_opts: [path: path]})
+    Application.put_env(Resolver, :telegram_token, @marker)
+
+    assert {:ok, stored} =
+             SQLiteMessaging.put_bridge_config(%{
+               id: "sqlite-secret",
+               adapter_module: Adapter,
+               secret_refs: %{token: :telegram_token}
+             })
+
+    bytes = path |> then(&Path.wildcard("#{&1}*")) |> Enum.map_join(&File.read!/1)
+    assert :binary.match(bytes, "telegram_token") != :nomatch
+    assert :binary.match(bytes, @marker) == :nomatch
+    refute inspect(stored) =~ @marker
+
+    on_exit(fn -> File.rm(path) end)
+  end
+
+  defp restore_env(application, key, nil), do: Application.delete_env(application, key)
+  defp restore_env(application, key, value), do: Application.put_env(application, key, value)
+end

--- a/test/jido_messaging/secret_resolver_test.exs
+++ b/test/jido_messaging/secret_resolver_test.exs
@@ -3,7 +3,8 @@ defmodule Jido.Messaging.SecretResolverTest do
 
   import ExUnit.CaptureLog
 
-  alias Jido.Messaging.OutboundGateway
+  alias Jido.Messaging.{BridgeConfig, OutboundGateway, Runtime, SecretResolver}
+  alias Jido.Messaging.Persistence.{ETS, SQLite}
 
   @marker "secret-marker-do-not-persist"
 
@@ -37,6 +38,19 @@ defmodule Jido.Messaging.SecretResolverTest do
 
       {:ok, %{message_id: "secret-test-#{text}"}}
     end
+  end
+
+  defmodule OtherAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :other_secret_test
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def send_message(_room_id, _text, _opts), do: {:ok, %{message_id: "wrong-adapter"}}
   end
 
   defmodule ETSMessaging do
@@ -108,6 +122,92 @@ defmodule Jido.Messaging.SecretResolverTest do
                adapter_module: Adapter,
                credentials: %{token: @marker}
              })
+  end
+
+  test "persistence adapters reject raw credentials when ConfigStore is bypassed" do
+    raw_config =
+      BridgeConfig.new(%{id: "raw-persistence", adapter_module: Adapter})
+      |> Map.put(:credentials, %{token: @marker})
+
+    {:ok, ets_state} = ETS.init([])
+
+    assert {:error, {:bridge_credentials_migration_required, "raw-persistence"}} =
+             ETS.save_bridge_config(ets_state, raw_config)
+
+    path = Path.join(System.tmp_dir!(), "jido-messaging-raw-secret-#{System.unique_integer([:positive])}.sqlite3")
+    File.rm(path)
+    {:ok, sqlite_state} = SQLite.init(path: path)
+
+    assert {:error, {:bridge_credentials_migration_required, "raw-persistence"}} =
+             SQLite.save_bridge_config(sqlite_state, raw_config)
+
+    :ok = Exqlite.Sqlite3.close(sqlite_state.db)
+    File.rm(path)
+  end
+
+  test "explicitly migrates a legacy credential record to secret references" do
+    start_supervised!(ETSMessaging)
+    {ETS, state} = Runtime.get_persistence(Module.concat(ETSMessaging, :Runtime))
+
+    legacy_config =
+      BridgeConfig.new(%{id: "legacy-secret", adapter_module: Adapter})
+      |> Map.put(:credentials, %{token: @marker})
+
+    true = :ets.insert(state.bridge_configs, {legacy_config.id, legacy_config})
+
+    assert {:ok, migrated} =
+             ETSMessaging.put_bridge_config(%{
+               id: legacy_config.id,
+               credentials: %{},
+               secret_refs: %{token: :telegram_token}
+             })
+
+    assert migrated.credentials == %{}
+    assert migrated.secret_refs == %{token: :telegram_token}
+    refute inspect(migrated) =~ @marker
+  end
+
+  test "requires an explicit replacement reference for legacy credentials" do
+    start_supervised!(ETSMessaging)
+    {ETS, state} = Runtime.get_persistence(Module.concat(ETSMessaging, :Runtime))
+
+    legacy_config =
+      BridgeConfig.new(%{id: "legacy-secret-required", adapter_module: Adapter})
+      |> Map.put(:credentials, %{token: @marker})
+
+    true = :ets.insert(state.bridge_configs, {legacy_config.id, legacy_config})
+
+    assert {:error, {:bridge_credentials_migration_required, "legacy-secret-required"}} =
+             ETSMessaging.put_bridge_config(%{id: legacy_config.id, credentials: %{}})
+  end
+
+  test "supports legacy bridge records without the secret_refs field" do
+    legacy_config =
+      BridgeConfig.new(%{id: "legacy-shape", adapter_module: Adapter})
+      |> Map.delete(:secret_refs)
+
+    assert {:ok, %{}} = apply(SecretResolver, :resolve_credentials, [ETSMessaging, legacy_config, :send])
+  end
+
+  test "does not resolve credentials for a different requested adapter" do
+    start_supervised!(ETSMessaging)
+    Application.put_env(Resolver, :telegram_token, @marker)
+
+    assert {:ok, stored} =
+             ETSMessaging.put_bridge_config(%{
+               id: "adapter-mismatch",
+               adapter_module: Adapter,
+               secret_refs: %{token: :telegram_token}
+             })
+
+    context = %{channel: OtherAdapter, bridge_id: stored.id, external_room_id: "room-1"}
+
+    assert {:error, error} = OutboundGateway.send_message(ETSMessaging, context, "blocked")
+
+    assert error.reason ==
+             {:bridge_adapter_mismatch, "adapter-mismatch", Adapter, OtherAdapter}
+
+    refute_receive {:adapter_credentials, _, _}
   end
 
   test "classifies resolver failures without diagnostic secret values" do


### PR DESCRIPTION
## Summary

- store opaque `secret_refs` in bridge configuration and keep the compatibility `credentials` field empty
- reject raw credentials in the config store and both durable persistence adapters
- publish a provider-neutral secret resolver contract and resolve values only when adapter work starts
- apply resolution to outbound delivery, webhook and payload processing, listener startup, and ingress subscription operations
- classify resolver failures without returning provider details, and document rotation and migration

## Verification

- `mix test test/jido_messaging/secret_resolver_test.exs` (4 passed)
- `mix test` (540 passed, 4 skipped, 13 excluded)
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- marker-secret test inspects SQLite database and WAL bytes and captured diagnostics

Closes #52