### PR TITLE
feat(history): add scoped participant transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,10 @@ remain the source of truth. Use `rebuild_transcript_search/3` to page through
 canonical history and replace the projection after data loss or a projection
 schema change. The core does not call projection `upsert/3` or `delete/3`
 callbacks from low-level persistence writes. Applications that maintain an
-incremental index must call those callbacks from their committed message event
-consumer. This keeps a failed optional index from changing canonical message
+incremental index call `upsert_transcript_search/3` and
+`delete_transcript_search/4` from their committed message event consumer. The
+helpers enforce the same instance and room scope before they invoke the
+projection. This keeps a failed optional index from changing canonical message
 commit behavior. Small deployments can omit a projection.
 
 ### Presence Signals

--- a/README.md
+++ b/README.md
@@ -135,6 +135,34 @@ use the explicit `"default"` bridge scope. SQLite assigns an unclaimed legacy
 participant record to the first matching scoped identity; applications can use
 the binding API before traffic starts when a different migration is required.
 
+### Participant Transcripts and Search Projections
+
+Participant history requires an instance-bound list of rooms that the caller
+is allowed to read:
+
+```elixir
+{:ok, scope} = MyApp.Messaging.history_scope(allowed_room_ids, %{policy: "support-agent"})
+
+{:ok, entries} =
+  MyApp.Messaging.participant_transcript("participant-123", scope,
+    limit: 50,
+    before: cursor_message_id
+  )
+```
+
+Each entry contains stable canonical message and participant IDs, the room ID,
+provider message and participant IDs, channel, bridge, timestamp, and the
+canonical message record. ETS and SQLite apply the same stable message cursor
+contract. A cursor outside the allowed rooms is reported as not found. A scope
+from one messaging instance cannot be used by another instance.
+
+Full-text search is optional. Configure a module that implements
+`Jido.Messaging.SearchProjection`, or pass it as the `:projection` option. The
+projection always receives the instance and `HistoryScope`. Canonical messages
+remain the source of truth. Use `rebuild_transcript_search/3` to page through
+canonical history and replace the projection after data loss or a projection
+schema change. Small deployments can omit a projection.
+
 ### Presence Signals
 
 `Jido.Messaging.Presence` bridges transport-specific presence state, such as

--- a/README.md
+++ b/README.md
@@ -161,7 +161,11 @@ Full-text search is optional. Configure a module that implements
 projection always receives the instance and `HistoryScope`. Canonical messages
 remain the source of truth. Use `rebuild_transcript_search/3` to page through
 canonical history and replace the projection after data loss or a projection
-schema change. Small deployments can omit a projection.
+schema change. The core does not call projection `upsert/3` or `delete/3`
+callbacks from low-level persistence writes. Applications that maintain an
+incremental index must call those callbacks from their committed message event
+consumer. This keeps a failed optional index from changing canonical message
+commit behavior. Small deployments can omit a projection.
 
 ### Presence Signals
 

--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -196,6 +196,38 @@ defmodule Jido.Messaging do
         Jido.Messaging.room_timeline(__jido_messaging__(:runtime), room_id, opts)
       end
 
+      @doc "Build an instance-bound authorization scope for history queries"
+      def history_scope(room_ids, metadata \\ %{}) do
+        Jido.Messaging.HistoryScope.new(__MODULE__, room_ids, metadata)
+      end
+
+      @doc "Return messages sent by one canonical participant in the allowed history scope"
+      def participant_transcript(participant_id, scope, opts \\ []) do
+        Jido.Messaging.participant_transcript(
+          __MODULE__,
+          __jido_messaging__(:runtime),
+          participant_id,
+          scope,
+          opts
+        )
+      end
+
+      @doc "Search an optional transcript projection within the allowed history scope"
+      def search_transcript(query, scope, opts \\ []) do
+        Jido.Messaging.search_transcript(__MODULE__, query, scope, opts)
+      end
+
+      @doc "Rebuild the optional search projection from canonical participant history"
+      def rebuild_transcript_search(participant_id, scope, opts \\ []) do
+        Jido.Messaging.rebuild_transcript_search(
+          __MODULE__,
+          __jido_messaging__(:runtime),
+          participant_id,
+          scope,
+          opts
+        )
+      end
+
       @doc "Delete a message"
       def delete_message(message_id) do
         Jido.Messaging.delete_message(__jido_messaging__(:runtime), message_id)
@@ -838,6 +870,51 @@ defmodule Jido.Messaging do
   def room_timeline(runtime, room_id, opts \\ []) do
     with {:ok, messages} <- list_messages(runtime, room_id, opts) do
       {:ok, Jido.Messaging.Query.room_timeline(messages)}
+    end
+  end
+
+  @doc """
+  Return participant-scoped canonical history within an explicit room scope.
+
+  The scope must belong to `instance_module`. The persistence query receives
+  only the allowed room IDs, so cursors from other rooms return
+  `{:error, :cursor_not_found}`.
+  """
+  def participant_transcript(instance_module, runtime, participant_id, scope, opts \\ [])
+      when is_atom(instance_module) and is_binary(participant_id) and is_list(opts) do
+    with :ok <- validate_history_scope(instance_module, scope),
+         {persistence, persistence_state} <- Runtime.get_persistence(runtime),
+         {:ok, participant} <- persistence.get_participant(persistence_state, participant_id),
+         {:ok, messages} <-
+           persistence.get_participant_messages(persistence_state, participant_id, scope.room_ids, opts) do
+      {:ok, Enum.map(messages, &Jido.Messaging.TranscriptEntry.new(instance_module, participant, &1))}
+    end
+  end
+
+  @doc "Search a configured optional transcript projection."
+  def search_transcript(instance_module, query, scope, opts \\ [])
+      when is_atom(instance_module) and is_binary(query) and is_list(opts) do
+    with :ok <- validate_history_scope(instance_module, scope),
+         {:ok, projection} <- search_projection(instance_module, opts),
+         :ok <- validate_projection(projection) do
+      context = %{instance_module: instance_module, scope: scope}
+
+      with {:ok, entries} <- projection.search(query, context, Keyword.delete(opts, :projection)),
+           :ok <- validate_projection_results(entries, instance_module, scope) do
+        {:ok, entries}
+      end
+    end
+  end
+
+  @doc "Rebuild a configured search projection from canonical participant history."
+  def rebuild_transcript_search(instance_module, runtime, participant_id, scope, opts \\ [])
+      when is_atom(instance_module) and is_binary(participant_id) and is_list(opts) do
+    with :ok <- validate_history_scope(instance_module, scope),
+         {:ok, projection} <- search_projection(instance_module, opts),
+         :ok <- validate_projection(projection),
+         {:ok, entries} <- collect_transcript(instance_module, runtime, participant_id, scope, opts) do
+      context = %{instance_module: instance_module, scope: scope}
+      projection.rebuild(entries, context, Keyword.drop(opts, [:projection, :batch_size]))
     end
   end
 
@@ -2161,6 +2238,99 @@ defmodule Jido.Messaging do
   end
 
   defp runtime_name(instance_module), do: Module.concat(instance_module, :Runtime)
+
+  defp validate_history_scope(
+         instance_module,
+         %Jido.Messaging.HistoryScope{instance_module: instance_module, room_ids: room_ids}
+       )
+       when is_list(room_ids),
+       do: :ok
+
+  defp validate_history_scope(_instance_module, %Jido.Messaging.HistoryScope{}) do
+    {:error, :history_scope_instance_mismatch}
+  end
+
+  defp validate_history_scope(_instance_module, _scope), do: {:error, :history_scope_required}
+
+  defp search_projection(instance_module, opts) do
+    projection =
+      Keyword.get(opts, :projection) ||
+        Application.get_env(instance_module, :search_projection) ||
+        Application.get_env(:jido_messaging, :search_projection)
+
+    if is_atom(projection) and not is_nil(projection) do
+      {:ok, projection}
+    else
+      {:error, :search_projection_not_configured}
+    end
+  end
+
+  defp validate_projection(projection) do
+    callbacks = [upsert: 3, delete: 3, search: 3, rebuild: 3]
+
+    if Code.ensure_loaded?(projection) and
+         Enum.all?(callbacks, fn {name, arity} -> function_exported?(projection, name, arity) end) do
+      :ok
+    else
+      {:error, :invalid_search_projection}
+    end
+  end
+
+  defp validate_projection_results(entries, instance_module, scope) when is_list(entries) do
+    allowed_rooms = MapSet.new(scope.room_ids)
+
+    if Enum.all?(entries, fn
+         %Jido.Messaging.TranscriptEntry{instance_module: ^instance_module, room_id: room_id} ->
+           MapSet.member?(allowed_rooms, room_id)
+
+         _other ->
+           false
+       end) do
+      :ok
+    else
+      {:error, :search_projection_scope_violation}
+    end
+  end
+
+  defp validate_projection_results(_entries, _instance_module, _scope) do
+    {:error, :invalid_search_projection_result}
+  end
+
+  defp collect_transcript(instance_module, runtime, participant_id, scope, opts) do
+    batch_size = opts |> Keyword.get(:batch_size, 500) |> normalize_transcript_batch_size()
+
+    page_opts =
+      opts
+      |> Keyword.drop([:projection, :batch_size, :before, :after])
+      |> Keyword.put(:limit, batch_size)
+
+    with {:ok, latest} <- participant_transcript(instance_module, runtime, participant_id, scope, page_opts) do
+      collect_older_transcript(instance_module, runtime, participant_id, scope, page_opts, latest)
+    end
+  end
+
+  defp collect_older_transcript(_instance_module, _runtime, _participant_id, _scope, _opts, []), do: {:ok, []}
+
+  defp collect_older_transcript(instance_module, runtime, participant_id, scope, opts, entries) do
+    before = entries |> List.first() |> Map.fetch!(:canonical_message_id)
+
+    case participant_transcript(instance_module, runtime, participant_id, scope, Keyword.put(opts, :before, before)) do
+      {:ok, []} ->
+        {:ok, entries}
+
+      {:ok, older} ->
+        with {:ok, all_older} <-
+               collect_older_transcript(instance_module, runtime, participant_id, scope, opts, older) do
+          {:ok, all_older ++ entries}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp normalize_transcript_batch_size(value) when is_integer(value) and value > 0, do: min(value, 1_000)
+  defp normalize_transcript_batch_size(_value), do: 500
 
   @doc "List running bridge workers for an instance module."
   def list_bridges(instance_module) when is_atom(instance_module) do

--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -2280,8 +2280,8 @@ defmodule Jido.Messaging do
     allowed_rooms = MapSet.new(scope.room_ids)
 
     if Enum.all?(entries, fn
-         %Jido.Messaging.TranscriptEntry{instance_module: ^instance_module, room_id: room_id} ->
-           MapSet.member?(allowed_rooms, room_id)
+         %Jido.Messaging.TranscriptEntry{instance_module: ^instance_module, room_id: room_id} = entry ->
+           MapSet.member?(allowed_rooms, room_id) and projection_entry_consistent?(entry)
 
          _other ->
            false
@@ -2295,6 +2295,23 @@ defmodule Jido.Messaging do
   defp validate_projection_results(_entries, _instance_module, _scope) do
     {:error, :invalid_search_projection_result}
   end
+
+  defp projection_entry_consistent?(%Jido.Messaging.TranscriptEntry{
+         canonical_message_id: canonical_message_id,
+         canonical_participant_id: canonical_participant_id,
+         room_id: room_id,
+         provider_message_id: provider_message_id,
+         inserted_at: inserted_at,
+         message: %Message{} = message
+       }) do
+    message.id == canonical_message_id and
+      message.sender_id == canonical_participant_id and
+      message.room_id == room_id and
+      message.external_id == provider_message_id and
+      message.inserted_at == inserted_at
+  end
+
+  defp projection_entry_consistent?(_entry), do: false
 
   defp collect_transcript(instance_module, runtime, participant_id, scope, opts) do
     batch_size = opts |> Keyword.get(:batch_size, 500) |> normalize_transcript_batch_size()

--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -217,6 +217,22 @@ defmodule Jido.Messaging do
         Jido.Messaging.search_transcript(__MODULE__, query, scope, opts)
       end
 
+      @doc "Upsert one committed canonical message into the optional search projection"
+      def upsert_transcript_search(message_id, scope, opts \\ []) do
+        Jido.Messaging.upsert_transcript_search(
+          __MODULE__,
+          __jido_messaging__(:runtime),
+          message_id,
+          scope,
+          opts
+        )
+      end
+
+      @doc "Delete one committed canonical message from the optional search projection"
+      def delete_transcript_search(message_id, room_id, scope, opts \\ []) do
+        Jido.Messaging.delete_transcript_search(__MODULE__, message_id, room_id, scope, opts)
+      end
+
       @doc "Rebuild the optional search projection from canonical participant history"
       def rebuild_transcript_search(participant_id, scope, opts \\ []) do
         Jido.Messaging.rebuild_transcript_search(
@@ -903,6 +919,34 @@ defmodule Jido.Messaging do
            :ok <- validate_projection_results(entries, instance_module, scope) do
         {:ok, entries}
       end
+    end
+  end
+
+  @doc "Upsert one committed canonical message into a configured search projection."
+  def upsert_transcript_search(instance_module, runtime, message_id, scope, opts \\ [])
+      when is_atom(instance_module) and is_binary(message_id) and is_list(opts) do
+    with :ok <- validate_history_scope(instance_module, scope),
+         {:ok, projection} <- search_projection(instance_module, opts),
+         :ok <- validate_projection(projection),
+         {persistence, persistence_state} <- Runtime.get_persistence(runtime),
+         {:ok, message} <- persistence.get_message(persistence_state, message_id),
+         :ok <- validate_history_room(scope, message.room_id),
+         {:ok, participant} <- persistence.get_participant(persistence_state, message.sender_id) do
+      entry = Jido.Messaging.TranscriptEntry.new(instance_module, participant, message)
+      context = %{instance_module: instance_module, scope: scope}
+      projection.upsert(entry, context, Keyword.delete(opts, :projection))
+    end
+  end
+
+  @doc "Delete one committed canonical message from a configured search projection."
+  def delete_transcript_search(instance_module, message_id, room_id, scope, opts \\ [])
+      when is_atom(instance_module) and is_binary(message_id) and is_binary(room_id) and is_list(opts) do
+    with :ok <- validate_history_scope(instance_module, scope),
+         :ok <- validate_history_room(scope, room_id),
+         {:ok, projection} <- search_projection(instance_module, opts),
+         :ok <- validate_projection(projection) do
+      context = %{instance_module: instance_module, scope: scope}
+      projection.delete(message_id, context, Keyword.delete(opts, :projection))
     end
   end
 
@@ -2251,6 +2295,10 @@ defmodule Jido.Messaging do
   end
 
   defp validate_history_scope(_instance_module, _scope), do: {:error, :history_scope_required}
+
+  defp validate_history_room(scope, room_id) do
+    if room_id in scope.room_ids, do: :ok, else: {:error, :history_scope_violation}
+  end
 
   defp search_projection(instance_module, opts) do
     projection =

--- a/lib/jido_messaging/history_scope.ex
+++ b/lib/jido_messaging/history_scope.ex
@@ -1,0 +1,43 @@
+defmodule Jido.Messaging.HistoryScope do
+  @moduledoc """
+  Mandatory instance and room authorization scope for history operations.
+
+  The caller must supply the rooms that its authorization policy permits.
+  History queries never expand this list.
+  """
+
+  @enforce_keys [:instance_module, :room_ids]
+  defstruct [:instance_module, :room_ids, metadata: %{}]
+
+  @type t :: %__MODULE__{
+          instance_module: module(),
+          room_ids: [String.t()],
+          metadata: map()
+        }
+
+  @doc "Builds an explicit history scope for one messaging instance."
+  @spec new(module(), [String.t()], map()) :: {:ok, t()} | {:error, :invalid_history_scope}
+  def new(instance_module, room_ids, metadata \\ %{})
+
+  def new(instance_module, room_ids, metadata)
+      when is_atom(instance_module) and is_list(room_ids) and is_map(metadata) do
+    room_ids = room_ids |> Enum.uniq() |> Enum.sort()
+
+    if Enum.all?(room_ids, &(is_binary(&1) and &1 != "")) do
+      {:ok, %__MODULE__{instance_module: instance_module, room_ids: room_ids, metadata: metadata}}
+    else
+      {:error, :invalid_history_scope}
+    end
+  end
+
+  def new(_instance_module, _room_ids, _metadata), do: {:error, :invalid_history_scope}
+
+  @doc "Builds a history scope and raises for invalid input."
+  @spec new!(module(), [String.t()], map()) :: t()
+  def new!(instance_module, room_ids, metadata \\ %{}) do
+    case new(instance_module, room_ids, metadata) do
+      {:ok, scope} -> scope
+      {:error, :invalid_history_scope} -> raise ArgumentError, "invalid history scope"
+    end
+  end
+end

--- a/lib/jido_messaging/persistence.ex
+++ b/lib/jido_messaging/persistence.ex
@@ -84,6 +84,14 @@ defmodule Jido.Messaging.Persistence do
   @doc "Delete a message by ID"
   @callback delete_message(state, message_id) :: :ok | {:error, term()}
 
+  @doc "Get messages sent by one canonical participant within explicit room scope"
+  @callback get_participant_messages(
+              state,
+              participant_id,
+              room_ids :: [room_id],
+              opts :: keyword()
+            ) :: {:ok, [Message.t()]} | {:error, term()}
+
   # Thread operations
   @doc "Save a thread"
   @callback save_thread(state, Thread.t()) :: {:ok, Thread.t()} | {:error, term()}

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -274,6 +274,20 @@ defmodule Jido.Messaging.Persistence.ETS do
     end
   end
 
+  @impl true
+  def get_participant_messages(state, participant_id, room_ids, opts \\ [])
+      when is_binary(participant_id) and is_list(room_ids) and is_list(opts) do
+    allowed_rooms = MapSet.new(room_ids)
+
+    messages =
+      state.messages
+      |> :ets.tab2list()
+      |> Enum.map(&elem(&1, 1))
+      |> Enum.filter(&(&1.sender_id == participant_id and MapSet.member?(allowed_rooms, &1.room_id)))
+
+    Jido.Messaging.Transcript.paginate(messages, opts)
+  end
+
   # Thread operations
 
   @impl true

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -118,6 +118,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
     persist(state, "message", message.id, message,
       room_id: message.room_id,
       thread_id: message.thread_id,
+      sender_id: message.sender_id,
       inserted_at: message.inserted_at,
       channel: metadata_value(metadata, :channel),
       bridge_id: metadata_value(metadata, :bridge_id),
@@ -218,23 +219,105 @@ defmodule Jido.Messaging.Persistence.SQLite do
 
   def get_participant_messages(state, participant_id, room_ids, opts)
       when is_binary(participant_id) and is_list(room_ids) and is_list(opts) do
-    room_params = room_ids |> Enum.with_index(2) |> Enum.map(fn {_room_id, index} -> "?#{index}" end)
+    limit = Keyword.get(opts, :limit, 50)
+
+    if is_integer(limit) and limit > 0 do
+      query_participant_messages(state, participant_id, room_ids, opts, limit)
+    else
+      {:error, :invalid_limit}
+    end
+  end
+
+  defp query_participant_messages(state, participant_id, room_ids, opts, limit) do
+    room_placeholders =
+      room_ids
+      |> Enum.with_index(3)
+      |> Enum.map_join(", ", fn {_room_id, index} -> "?#{index}" end)
+
+    where = "kind = ?1 AND sender_id = ?2 AND room_id IN (#{room_placeholders})"
+    params = ["message", participant_id | room_ids]
+    {where, params} = with_instance_scope(state, where, params)
+
+    case participant_cursor_direction(opts) do
+      :none ->
+        query_participant_page(state.db, where, params, "DESC", limit, true)
+
+      {:before, cursor_id} ->
+        with {:ok, {inserted_at, id}} <- participant_cursor(state.db, where, params, cursor_id) do
+          timestamp_param = length(params) + 1
+          id_param = timestamp_param + 1
+
+          cursor_where =
+            "#{where} AND (COALESCE(inserted_at, '') < ?#{timestamp_param} OR " <>
+              "(COALESCE(inserted_at, '') = ?#{timestamp_param} AND id < ?#{id_param}))"
+
+          query_participant_page(state.db, cursor_where, params ++ [inserted_at, id], "DESC", limit, true)
+        end
+
+      {:after, cursor_id} ->
+        with {:ok, {inserted_at, id}} <- participant_cursor(state.db, where, params, cursor_id) do
+          timestamp_param = length(params) + 1
+          id_param = timestamp_param + 1
+
+          cursor_where =
+            "#{where} AND (COALESCE(inserted_at, '') > ?#{timestamp_param} OR " <>
+              "(COALESCE(inserted_at, '') = ?#{timestamp_param} AND id > ?#{id_param}))"
+
+          query_participant_page(state.db, cursor_where, params ++ [inserted_at, id], "ASC", limit, false)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp participant_cursor(db, where, params, cursor_id) do
+    cursor_param = length(params) + 1
 
     with {:ok, rows} <-
            query_all(
-             state.db,
+             db,
+             """
+             SELECT COALESCE(inserted_at, ''), id
+             FROM #{@table}
+             WHERE #{where} AND id = ?#{cursor_param}
+             LIMIT 1
+             """,
+             params ++ [cursor_id]
+           ) do
+      case rows do
+        [[inserted_at, id]] -> {:ok, {inserted_at, id}}
+        [] -> {:error, :cursor_not_found}
+      end
+    end
+  end
+
+  defp query_participant_page(db, where, params, direction, limit, reverse?) do
+    limit_param = length(params) + 1
+
+    with {:ok, rows} <-
+           query_all(
+             db,
              """
              SELECT payload
              FROM #{@table}
-             WHERE kind = ?1 AND room_id IN (#{Enum.join(room_params, ", ")})
-             ORDER BY inserted_at ASC, id ASC
+             WHERE #{where}
+             ORDER BY COALESCE(inserted_at, '') #{direction}, id #{direction}
+             LIMIT ?#{limit_param}
              """,
-             ["message" | room_ids]
+             params ++ [limit]
            ) do
-      rows
-      |> decode_rows()
-      |> Enum.filter(&(&1.sender_id == participant_id))
-      |> Jido.Messaging.Transcript.paginate(opts)
+      messages = decode_rows(rows)
+      {:ok, if(reverse?, do: Enum.reverse(messages), else: messages)}
+    end
+  end
+
+  defp participant_cursor_direction(opts) do
+    case {Keyword.get(opts, :before), Keyword.get(opts, :after)} do
+      {nil, nil} -> :none
+      {before, nil} when is_binary(before) and before != "" -> {:before, before}
+      {nil, after_cursor} when is_binary(after_cursor) and after_cursor != "" -> {:after, after_cursor}
+      {_before, _after_cursor} -> {:error, :invalid_cursor_options}
     end
   end
 
@@ -595,17 +678,23 @@ defmodule Jido.Messaging.Persistence.SQLite do
            PRAGMA journal_mode = WAL;
            PRAGMA synchronous = NORMAL;
            """),
-         {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []) do
-      cond do
-        columns == [] ->
-          with :ok <- exec(db, create_table_sql()), do: migrate_binding_indexes(db)
+         {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []),
+         :ok <- migrate_schema(db, columns, instance_id),
+         :ok <- ensure_sender_id_column(db),
+         :ok <- backfill_message_sender_ids(db) do
+      create_history_index(db)
+    end
+  end
 
-        Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) ->
-          migrate_binding_indexes(db)
+  defp migrate_schema(db, [], _instance_id) do
+    with :ok <- exec(db, create_table_sql()), do: migrate_binding_indexes(db)
+  end
 
-        true ->
-          migrate_legacy_table(db, instance_id)
-      end
+  defp migrate_schema(db, columns, instance_id) do
+    if Enum.any?(columns, fn [_cid, name | _rest] -> name == "instance_id" end) do
+      migrate_binding_indexes(db)
+    else
+      migrate_legacy_table(db, instance_id)
     end
   end
 
@@ -669,6 +758,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
       id TEXT NOT NULL,
       room_id TEXT,
       thread_id TEXT,
+      sender_id TEXT,
       inserted_at TEXT,
       channel TEXT,
       bridge_id TEXT,
@@ -741,6 +831,49 @@ defmodule Jido.Messaging.Persistence.SQLite do
     """)
   end
 
+  defp ensure_sender_id_column(db) do
+    with {:ok, columns} <- query_all(db, "PRAGMA table_info(#{@table})", []) do
+      if Enum.any?(columns, fn [_index, name | _rest] -> name == "sender_id" end) do
+        :ok
+      else
+        exec(db, "ALTER TABLE #{@table} ADD COLUMN sender_id TEXT")
+      end
+    end
+  end
+
+  defp backfill_message_sender_ids(db) do
+    with {:ok, rows} <-
+           query_all(
+             db,
+             "SELECT instance_id, id, payload FROM #{@table} WHERE kind = 'message' AND sender_id IS NULL",
+             []
+           ) do
+      Enum.reduce_while(rows, :ok, fn [instance_id, id, payload], :ok ->
+        case :erlang.binary_to_term(payload) do
+          %Message{sender_id: sender_id} ->
+            case run(
+                   db,
+                   "UPDATE #{@table} SET sender_id = ?1 WHERE instance_id = ?2 AND kind = 'message' AND id = ?3",
+                   [sender_id, instance_id, id]
+                 ) do
+              :ok -> {:cont, :ok}
+              {:error, _reason} = error -> {:halt, error}
+            end
+
+          _other ->
+            {:cont, :ok}
+        end
+      end)
+    end
+  end
+
+  defp create_history_index(db) do
+    exec(db, """
+    CREATE INDEX IF NOT EXISTS #{@table}_participant_history_idx
+      ON #{@table} (instance_id, kind, sender_id, inserted_at, id);
+    """)
+  end
+
   defp persist(state, kind, id, record, opts \\ []) do
     with :ok <- upsert_record(state, kind, id, record, opts) do
       {:ok, record}
@@ -752,11 +885,12 @@ defmodule Jido.Messaging.Persistence.SQLite do
       state.db,
       """
       INSERT INTO #{@table}
-        (instance_id, kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        (instance_id, kind, id, room_id, thread_id, sender_id, inserted_at, channel, bridge_id, external_id, payload)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
       ON CONFLICT(instance_id, kind, id) DO UPDATE SET
         room_id = excluded.room_id,
         thread_id = excluded.thread_id,
+        sender_id = excluded.sender_id,
         inserted_at = excluded.inserted_at,
         channel = excluded.channel,
         bridge_id = excluded.bridge_id,
@@ -769,6 +903,7 @@ defmodule Jido.Messaging.Persistence.SQLite do
         id,
         Keyword.get(opts, :room_id),
         Keyword.get(opts, :thread_id),
+        Keyword.get(opts, :sender_id),
         format_datetime(Keyword.get(opts, :inserted_at)),
         opts |> Keyword.get(:channel) |> normalize_nullable(),
         opts |> Keyword.get(:bridge_id) |> normalize_nullable(),

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -212,6 +212,33 @@ defmodule Jido.Messaging.Persistence.SQLite do
   end
 
   @impl true
+  def get_participant_messages(state, participant_id, room_ids, opts \\ [])
+
+  def get_participant_messages(_state, _participant_id, [], _opts), do: {:ok, []}
+
+  def get_participant_messages(state, participant_id, room_ids, opts)
+      when is_binary(participant_id) and is_list(room_ids) and is_list(opts) do
+    room_params = room_ids |> Enum.with_index(2) |> Enum.map(fn {_room_id, index} -> "?#{index}" end)
+
+    with {:ok, rows} <-
+           query_all(
+             state.db,
+             """
+             SELECT payload
+             FROM #{@table}
+             WHERE kind = ?1 AND room_id IN (#{Enum.join(room_params, ", ")})
+             ORDER BY inserted_at ASC, id ASC
+             """,
+             ["message" | room_ids]
+           ) do
+      rows
+      |> decode_rows()
+      |> Enum.filter(&(&1.sender_id == participant_id))
+      |> Jido.Messaging.Transcript.paginate(opts)
+    end
+  end
+
+  @impl true
   def save_thread(state, %Thread{} = thread) do
     persist(state, "thread", thread.id, thread,
       room_id: thread.room_id,

--- a/lib/jido_messaging/search_projection.ex
+++ b/lib/jido_messaging/search_projection.ex
@@ -1,0 +1,22 @@
+defmodule Jido.Messaging.SearchProjection do
+  @moduledoc """
+  Optional search projection contract for canonical transcript entries.
+
+  Canonical persistence remains the source of truth. A projection consumes
+  committed entries and can be rebuilt from `participant_transcript/3`. Search
+  implementations must apply the supplied `HistoryScope` and instance module.
+  """
+
+  alias Jido.Messaging.{HistoryScope, TranscriptEntry}
+
+  @type context :: %{
+          required(:instance_module) => module(),
+          required(:scope) => HistoryScope.t()
+        }
+
+  @callback upsert(TranscriptEntry.t(), context(), keyword()) :: :ok | {:error, term()}
+  @callback delete(String.t(), context(), keyword()) :: :ok | {:error, term()}
+  @callback search(String.t(), context(), keyword()) ::
+              {:ok, [TranscriptEntry.t()]} | {:error, term()}
+  @callback rebuild([TranscriptEntry.t()], context(), keyword()) :: :ok | {:error, term()}
+end

--- a/lib/jido_messaging/search_projection.ex
+++ b/lib/jido_messaging/search_projection.ex
@@ -6,10 +6,11 @@ defmodule Jido.Messaging.SearchProjection do
   committed entries and can be rebuilt from `participant_transcript/3`. Search
   implementations must apply the supplied `HistoryScope` and instance module.
 
-  The messaging core calls `search/3` and `rebuild/3`. Applications call
-  `upsert/3` and `delete/3` from a committed message event consumer when they
-  need incremental indexing. Projection failure does not roll back canonical
-  persistence.
+  The messaging core calls `search/3` and `rebuild/3`. Applications use
+  `upsert_transcript_search/3` and `delete_transcript_search/4` from a committed
+  message event consumer when they need incremental indexing. These helpers
+  invoke `upsert/3` and `delete/3` after scope checks. Projection failure does
+  not roll back canonical persistence.
   """
 
   alias Jido.Messaging.{HistoryScope, TranscriptEntry}

--- a/lib/jido_messaging/search_projection.ex
+++ b/lib/jido_messaging/search_projection.ex
@@ -5,6 +5,11 @@ defmodule Jido.Messaging.SearchProjection do
   Canonical persistence remains the source of truth. A projection consumes
   committed entries and can be rebuilt from `participant_transcript/3`. Search
   implementations must apply the supplied `HistoryScope` and instance module.
+
+  The messaging core calls `search/3` and `rebuild/3`. Applications call
+  `upsert/3` and `delete/3` from a committed message event consumer when they
+  need incremental indexing. Projection failure does not roll back canonical
+  persistence.
   """
 
   alias Jido.Messaging.{HistoryScope, TranscriptEntry}

--- a/lib/jido_messaging/transcript.ex
+++ b/lib/jido_messaging/transcript.ex
@@ -53,7 +53,9 @@ defmodule Jido.Messaging.Transcript do
     end
   end
 
-  defp order_key(message) do
-    {DateTime.to_unix(message.inserted_at, :microsecond), message.id}
+  defp order_key(%Message{inserted_at: %DateTime{} = inserted_at, id: id}) do
+    {DateTime.to_iso8601(inserted_at), id}
   end
+
+  defp order_key(%Message{id: id}), do: {"", id}
 end

--- a/lib/jido_messaging/transcript.ex
+++ b/lib/jido_messaging/transcript.ex
@@ -1,0 +1,59 @@
+defmodule Jido.Messaging.Transcript do
+  @moduledoc false
+
+  alias Jido.Messaging.Message
+
+  @spec paginate([Message.t()], keyword()) :: {:ok, [Message.t()]} | {:error, term()}
+  def paginate(messages, opts) when is_list(messages) and is_list(opts) do
+    limit = Keyword.get(opts, :limit, 50)
+    messages = Enum.sort_by(messages, &order_key/1)
+
+    if is_integer(limit) and limit > 0 do
+      paginate_with_cursor(messages, opts, limit)
+    else
+      {:error, :invalid_limit}
+    end
+  end
+
+  defp paginate_with_cursor(messages, opts, limit) do
+    case cursor_direction(opts) do
+      :none ->
+        {:ok, Enum.take(messages, -limit)}
+
+      {:before, cursor_id} ->
+        with {:ok, cursor} <- find_cursor(messages, cursor_id) do
+          page = messages |> Enum.filter(&(order_key(&1) < order_key(cursor))) |> Enum.take(-limit)
+          {:ok, page}
+        end
+
+      {:after, cursor_id} ->
+        with {:ok, cursor} <- find_cursor(messages, cursor_id) do
+          page = messages |> Enum.filter(&(order_key(&1) > order_key(cursor))) |> Enum.take(limit)
+          {:ok, page}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp cursor_direction(opts) do
+    case {Keyword.get(opts, :before), Keyword.get(opts, :after)} do
+      {nil, nil} -> :none
+      {before, nil} when is_binary(before) and before != "" -> {:before, before}
+      {nil, after_cursor} when is_binary(after_cursor) and after_cursor != "" -> {:after, after_cursor}
+      {_before, _after_cursor} -> {:error, :invalid_cursor_options}
+    end
+  end
+
+  defp find_cursor(messages, cursor_id) do
+    case Enum.find(messages, &(&1.id == cursor_id)) do
+      nil -> {:error, :cursor_not_found}
+      cursor -> {:ok, cursor}
+    end
+  end
+
+  defp order_key(message) do
+    {DateTime.to_unix(message.inserted_at, :microsecond), message.id}
+  end
+end

--- a/lib/jido_messaging/transcript_entry.ex
+++ b/lib/jido_messaging/transcript_entry.ex
@@ -1,0 +1,74 @@
+defmodule Jido.Messaging.TranscriptEntry do
+  @moduledoc """
+  Canonical transcript result with provider identity fields.
+  """
+
+  alias Jido.Chat.Participant
+  alias Jido.Messaging.Message
+
+  @enforce_keys [
+    :instance_module,
+    :canonical_message_id,
+    :canonical_participant_id,
+    :room_id,
+    :inserted_at,
+    :message
+  ]
+  defstruct [
+    :instance_module,
+    :canonical_message_id,
+    :canonical_participant_id,
+    :room_id,
+    :channel,
+    :bridge_id,
+    :provider_message_id,
+    :provider_participant_id,
+    :inserted_at,
+    :message
+  ]
+
+  @type t :: %__MODULE__{
+          instance_module: module(),
+          canonical_message_id: String.t(),
+          canonical_participant_id: String.t(),
+          room_id: String.t(),
+          channel: atom() | String.t() | nil,
+          bridge_id: String.t() | nil,
+          provider_message_id: String.t() | nil,
+          provider_participant_id: String.t() | nil,
+          inserted_at: DateTime.t(),
+          message: Message.t()
+        }
+
+  @doc "Builds a transcript entry from canonical participant and message records."
+  @spec new(module(), Participant.t(), Message.t()) :: t()
+  def new(instance_module, %Participant{} = participant, %Message{} = message) when is_atom(instance_module) do
+    channel = metadata_value(message.metadata, :channel)
+
+    %__MODULE__{
+      instance_module: instance_module,
+      canonical_message_id: message.id,
+      canonical_participant_id: participant.id,
+      room_id: message.room_id,
+      channel: channel,
+      bridge_id: metadata_value(message.metadata, :bridge_id),
+      provider_message_id: message.external_id,
+      provider_participant_id: provider_participant_id(participant, channel),
+      inserted_at: message.inserted_at,
+      message: message
+    }
+  end
+
+  defp provider_participant_id(_participant, nil), do: nil
+
+  defp provider_participant_id(participant, channel) do
+    external_ids = participant.external_ids || %{}
+    Map.get(external_ids, channel) || Map.get(external_ids, to_string(channel))
+  end
+
+  defp metadata_value(metadata, key) when is_map(metadata) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+  end
+
+  defp metadata_value(_metadata, _key), do: nil
+end

--- a/test/jido_messaging/participant_transcript_test.exs
+++ b/test/jido_messaging/participant_transcript_test.exs
@@ -1,0 +1,251 @@
+defmodule Jido.Messaging.ParticipantTranscriptTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Messaging.TranscriptEntry
+
+  defmodule ETSMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
+  end
+
+  defmodule SQLiteMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.SQLite
+  end
+
+  defmodule Projection do
+    @behaviour Jido.Messaging.SearchProjection
+
+    @impl true
+    def upsert(_entry, _context, _opts), do: :ok
+
+    @impl true
+    def delete(_message_id, _context, _opts), do: :ok
+
+    @impl true
+    def search(query, context, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:projection_search, query, context})
+      {:ok, Keyword.get(opts, :results, [])}
+    end
+
+    @impl true
+    def rebuild(entries, context, opts) do
+      send(Keyword.fetch!(opts, :test_pid), {:projection_rebuild, entries, context})
+      :ok
+    end
+  end
+
+  setup do
+    path = Path.join(System.tmp_dir!(), "jido-messaging-transcript-#{System.unique_integer([:positive])}.sqlite3")
+    File.rm(path)
+
+    start_supervised!(ETSMessaging)
+    start_supervised!({SQLiteMessaging, persistence_opts: [path: path]})
+
+    on_exit(fn -> File.rm(path) end)
+    :ok
+  end
+
+  test "ETS and SQLite return the same scoped participant transcript" do
+    for messaging <- [ETSMessaging, SQLiteMessaging] do
+      records = seed_transcript(messaging)
+      assert {:ok, scope} = messaging.history_scope([records.room_one.id, records.room_two.id])
+
+      assert {:ok, entries} = messaging.participant_transcript(records.participant.id, scope, limit: 10)
+
+      assert Enum.map(entries, & &1.canonical_message_id) ==
+               Enum.map(records.allowed_messages, & &1.id)
+
+      assert Enum.all?(entries, &match?(%TranscriptEntry{}, &1))
+      assert Enum.all?(entries, &(&1.instance_module == messaging))
+      refute Enum.any?(entries, &(&1.room_id == records.denied_room.id))
+
+      [slack_entry, telegram_entry, _slack_entry] = entries
+      assert slack_entry.canonical_participant_id == records.participant.id
+      assert slack_entry.provider_participant_id == "U-provider"
+      assert slack_entry.provider_message_id == "slack-message-1"
+      assert slack_entry.channel == :slack
+      assert slack_entry.bridge_id == "slack-main"
+      assert telegram_entry.provider_participant_id == "T-provider"
+      assert telegram_entry.provider_message_id == "telegram-message-1"
+
+      assert {:ok, after_page} =
+               messaging.participant_transcript(records.participant.id, scope,
+                 after: List.first(records.allowed_messages).id,
+                 limit: 10
+               )
+
+      assert Enum.map(after_page, & &1.canonical_message_id) ==
+               records.allowed_messages |> Enum.drop(1) |> Enum.map(& &1.id)
+
+      assert {:ok, before_page} =
+               messaging.participant_transcript(records.participant.id, scope,
+                 before: List.last(records.allowed_messages).id,
+                 limit: 10
+               )
+
+      assert Enum.map(before_page, & &1.canonical_message_id) ==
+               records.allowed_messages |> Enum.drop(-1) |> Enum.map(& &1.id)
+
+      assert {:error, :cursor_not_found} =
+               messaging.participant_transcript(records.participant.id, scope,
+                 before: records.denied_message.id,
+                 limit: 10
+               )
+    end
+  end
+
+  test "history scope is mandatory and bound to one instance" do
+    records = seed_transcript(ETSMessaging)
+    assert {:ok, ets_scope} = ETSMessaging.history_scope([records.room_one.id])
+
+    assert {:error, :history_scope_required} =
+             ETSMessaging.participant_transcript(records.participant.id, %{room_ids: [records.room_one.id]})
+
+    assert {:error, :history_scope_instance_mismatch} =
+             SQLiteMessaging.participant_transcript(records.participant.id, ets_scope)
+  end
+
+  test "optional projection receives mandatory scope and can rebuild from canonical history" do
+    records = seed_transcript(ETSMessaging)
+    assert {:ok, scope} = ETSMessaging.history_scope([records.room_one.id, records.room_two.id])
+
+    assert {:error, :search_projection_not_configured} =
+             ETSMessaging.search_transcript("hello", scope)
+
+    assert {:ok, []} =
+             ETSMessaging.search_transcript("hello", scope,
+               projection: Projection,
+               test_pid: self()
+             )
+
+    assert_receive {:projection_search, "hello", %{instance_module: ETSMessaging, scope: ^scope}}
+
+    assert {:ok, [entry | _entries]} =
+             ETSMessaging.participant_transcript(records.participant.id, scope, limit: 10)
+
+    leaked_entry = %{entry | room_id: records.denied_room.id}
+
+    assert {:error, :search_projection_scope_violation} =
+             ETSMessaging.search_transcript("leak", scope,
+               projection: Projection,
+               test_pid: self(),
+               results: [leaked_entry]
+             )
+
+    assert :ok =
+             ETSMessaging.rebuild_transcript_search(records.participant.id, scope,
+               projection: Projection,
+               batch_size: 2,
+               test_pid: self()
+             )
+
+    assert_receive {:projection_rebuild, entries, %{instance_module: ETSMessaging, scope: ^scope}}
+    assert Enum.map(entries, & &1.canonical_message_id) == Enum.map(records.allowed_messages, & &1.id)
+  end
+
+  defp seed_transcript(messaging) do
+    prefix = messaging |> Module.split() |> List.last() |> String.downcase()
+
+    {:ok, room_one} = messaging.create_room(%{id: "#{prefix}-room-1", type: :group})
+    {:ok, room_two} = messaging.create_room(%{id: "#{prefix}-room-2", type: :group})
+    {:ok, denied_room} = messaging.create_room(%{id: "#{prefix}-room-denied", type: :group})
+
+    {:ok, participant} =
+      messaging.create_participant(%{
+        id: "#{prefix}-participant",
+        type: :human,
+        identity: %{name: "Linked person"},
+        external_ids: %{slack: "U-provider", telegram: "T-provider"}
+      })
+
+    {:ok, other_participant} =
+      messaging.create_participant(%{
+        id: "#{prefix}-other-participant",
+        type: :human,
+        identity: %{name: "Other person"}
+      })
+
+    base = DateTime.from_unix!(1_700_000_000)
+
+    allowed_messages = [
+      save_message(
+        messaging,
+        participant.id,
+        room_one.id,
+        "#{prefix}-message-1",
+        base,
+        :slack,
+        "slack-main",
+        "slack-message-1"
+      ),
+      save_message(
+        messaging,
+        participant.id,
+        room_two.id,
+        "#{prefix}-message-2",
+        DateTime.add(base, 1, :second),
+        :telegram,
+        "telegram-main",
+        "telegram-message-1"
+      ),
+      save_message(
+        messaging,
+        participant.id,
+        room_one.id,
+        "#{prefix}-message-3",
+        DateTime.add(base, 2, :second),
+        :slack,
+        "slack-main",
+        "slack-message-2"
+      )
+    ]
+
+    denied_message =
+      save_message(
+        messaging,
+        participant.id,
+        denied_room.id,
+        "#{prefix}-message-denied",
+        DateTime.add(base, 3, :second),
+        :slack,
+        "slack-main",
+        "slack-message-denied"
+      )
+
+    _other_message =
+      save_message(
+        messaging,
+        other_participant.id,
+        room_one.id,
+        "#{prefix}-message-other",
+        DateTime.add(base, 4, :second),
+        :slack,
+        "slack-main",
+        "slack-message-other"
+      )
+
+    %{
+      room_one: room_one,
+      room_two: room_two,
+      denied_room: denied_room,
+      participant: participant,
+      allowed_messages: allowed_messages,
+      denied_message: denied_message
+    }
+  end
+
+  defp save_message(messaging, participant_id, room_id, id, inserted_at, channel, bridge_id, external_id) do
+    {:ok, message} =
+      messaging.save_message(%{
+        id: id,
+        room_id: room_id,
+        sender_id: participant_id,
+        role: :user,
+        content: [%{type: :text, text: id}],
+        external_id: external_id,
+        inserted_at: inserted_at,
+        metadata: %{channel: channel, bridge_id: bridge_id}
+      })
+
+    message
+  end
+end

--- a/test/jido_messaging/participant_transcript_test.exs
+++ b/test/jido_messaging/participant_transcript_test.exs
@@ -15,10 +15,16 @@ defmodule Jido.Messaging.ParticipantTranscriptTest do
     @behaviour Jido.Messaging.SearchProjection
 
     @impl true
-    def upsert(_entry, _context, _opts), do: :ok
+    def upsert(entry, context, opts) do
+      if test_pid = Keyword.get(opts, :test_pid), do: send(test_pid, {:projection_upsert, entry, context})
+      :ok
+    end
 
     @impl true
-    def delete(_message_id, _context, _opts), do: :ok
+    def delete(message_id, context, opts) do
+      if test_pid = Keyword.get(opts, :test_pid), do: send(test_pid, {:projection_delete, message_id, context})
+      :ok
+    end
 
     @impl true
     def search(query, context, opts) do
@@ -121,6 +127,29 @@ defmodule Jido.Messaging.ParticipantTranscriptTest do
 
     assert {:ok, [entry | _entries]} =
              ETSMessaging.participant_transcript(records.participant.id, scope, limit: 10)
+
+    assert :ok =
+             ETSMessaging.upsert_transcript_search(entry.canonical_message_id, scope,
+               projection: Projection,
+               test_pid: self()
+             )
+
+    assert_receive {:projection_upsert, ^entry, %{instance_module: ETSMessaging, scope: ^scope}}
+
+    assert :ok =
+             ETSMessaging.delete_transcript_search(entry.canonical_message_id, entry.room_id, scope,
+               projection: Projection,
+               test_pid: self()
+             )
+
+    assert_receive {:projection_delete, message_id, %{instance_module: ETSMessaging, scope: ^scope}}
+    assert message_id == entry.canonical_message_id
+
+    assert {:error, :history_scope_violation} =
+             ETSMessaging.delete_transcript_search(entry.canonical_message_id, records.denied_room.id, scope,
+               projection: Projection,
+               test_pid: self()
+             )
 
     leaked_entry = %{entry | room_id: records.denied_room.id}
 

--- a/test/jido_messaging/participant_transcript_test.exs
+++ b/test/jido_messaging/participant_transcript_test.exs
@@ -131,6 +131,24 @@ defmodule Jido.Messaging.ParticipantTranscriptTest do
                results: [leaked_entry]
              )
 
+    nested_room_leak = %{entry | message: %{entry.message | room_id: records.denied_room.id}}
+
+    assert {:error, :search_projection_scope_violation} =
+             ETSMessaging.search_transcript("nested leak", scope,
+               projection: Projection,
+               test_pid: self(),
+               results: [nested_room_leak]
+             )
+
+    mismatched_id = %{entry | message: %{entry.message | id: "different-message"}}
+
+    assert {:error, :search_projection_scope_violation} =
+             ETSMessaging.search_transcript("mismatched id", scope,
+               projection: Projection,
+               test_pid: self(),
+               results: [mismatched_id]
+             )
+
     assert :ok =
              ETSMessaging.rebuild_transcript_search(records.participant.id, scope,
                projection: Projection,
@@ -140,6 +158,57 @@ defmodule Jido.Messaging.ParticipantTranscriptTest do
 
     assert_receive {:projection_rebuild, entries, %{instance_module: ETSMessaging, scope: ^scope}}
     assert Enum.map(entries, & &1.canonical_message_id) == Enum.map(records.allowed_messages, & &1.id)
+  end
+
+  test "ETS and SQLite paginate messages with nullable timestamps" do
+    for messaging <- [ETSMessaging, SQLiteMessaging] do
+      prefix = messaging |> Module.split() |> List.last() |> String.downcase()
+      {:ok, room} = messaging.create_room(%{id: "#{prefix}-nullable-room", type: :group})
+
+      {:ok, participant} =
+        messaging.create_participant(%{
+          id: "#{prefix}-nullable-participant",
+          type: :human,
+          identity: %{name: "Nullable User"}
+        })
+
+      without_timestamp =
+        save_message(
+          messaging,
+          participant.id,
+          room.id,
+          "#{prefix}-nullable-message",
+          nil,
+          :slack,
+          "slack-main",
+          "nullable-provider-message"
+        )
+
+      with_timestamp =
+        save_message(
+          messaging,
+          participant.id,
+          room.id,
+          "#{prefix}-dated-message",
+          DateTime.from_unix!(1_700_000_000),
+          :slack,
+          "slack-main",
+          "dated-provider-message"
+        )
+
+      assert {:ok, scope} = messaging.history_scope([room.id])
+      assert {:ok, entries} = messaging.participant_transcript(participant.id, scope, limit: 10)
+
+      assert Enum.map(entries, & &1.canonical_message_id) == [without_timestamp.id, with_timestamp.id]
+
+      assert {:ok, [before_entry]} =
+               messaging.participant_transcript(participant.id, scope,
+                 before: with_timestamp.id,
+                 limit: 10
+               )
+
+      assert before_entry.canonical_message_id == without_timestamp.id
+    end
   end
 
   defp seed_transcript(messaging) do

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -534,6 +534,7 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
 
   test "backfills sender IDs for participant transcript queries" do
     path = tmp_path("sqlite-participant-sender-migration")
+    File.mkdir_p!(Path.dirname(path))
     {:ok, db} = Sqlite3.open(path)
 
     :ok =

--- a/test/jido_messaging/persistence/sqlite_test.exs
+++ b/test/jido_messaging/persistence/sqlite_test.exs
@@ -532,6 +532,77 @@ defmodule Jido.Messaging.Persistence.SQLiteTest do
     :ok = Sqlite3.close(state.db)
   end
 
+  test "backfills sender IDs for participant transcript queries" do
+    path = tmp_path("sqlite-participant-sender-migration")
+    {:ok, db} = Sqlite3.open(path)
+
+    :ok =
+      Sqlite3.execute(db, """
+      CREATE TABLE jido_messaging_records (
+        kind TEXT NOT NULL,
+        id TEXT NOT NULL,
+        room_id TEXT,
+        thread_id TEXT,
+        inserted_at TEXT,
+        channel TEXT,
+        bridge_id TEXT,
+        external_id TEXT,
+        payload BLOB NOT NULL,
+        PRIMARY KEY (kind, id)
+      );
+      """)
+
+    legacy_message =
+      Message.new(%{
+        id: "message:legacy-sender",
+        room_id: "room:legacy-sender",
+        sender_id: "participant:legacy-sender",
+        role: :user,
+        content: [%{type: "text", text: "legacy"}],
+        inserted_at: DateTime.from_unix!(1_700_000_000),
+        status: :sent
+      })
+
+    {:ok, statement} =
+      Sqlite3.prepare(
+        db,
+        """
+        INSERT INTO jido_messaging_records
+          (kind, id, room_id, thread_id, inserted_at, channel, bridge_id, external_id, payload)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)
+        """
+      )
+
+    :ok =
+      Sqlite3.bind(statement, [
+        "message",
+        legacy_message.id,
+        legacy_message.room_id,
+        nil,
+        DateTime.to_iso8601(legacy_message.inserted_at),
+        nil,
+        nil,
+        nil,
+        {:blob, :erlang.term_to_binary(legacy_message)}
+      ])
+
+    :done = Sqlite3.step(db, statement)
+    :ok = Sqlite3.release(db, statement)
+    :ok = Sqlite3.close(db)
+
+    {:ok, state} = SQLite.init(path: path)
+
+    assert {:ok, [^legacy_message]} =
+             SQLite.get_participant_messages(
+               state,
+               legacy_message.sender_id,
+               [legacy_message.room_id],
+               limit: 10
+             )
+
+    :ok = Sqlite3.close(state.db)
+  end
+
   test "room_timeline returns raw timeline messages and thread replies" do
     path = tmp_path("sqlite-query")
     start_supervised!({SQLiteMessaging, persistence_opts: [path: path]})


### PR DESCRIPTION
## Summary

- add mandatory instance-bound `HistoryScope` values for participant history and search
- add participant transcript queries to ETS and SQLite with stable before/after message cursors
- return canonical and provider message and participant identity in typed transcript entries
- add an optional search projection contract with bounded canonical rebuilds
- reject cross-instance scopes, out-of-scope cursors, and projection results outside the allowed instance and rooms

## Notes

PR #61 supplies the focused same-file SQLite instance namespace fix. This PR enforces instance scope at the public history and projection boundaries and limits SQLite reads to authorized room IDs.

## Verification

- `mix test test/jido_messaging/participant_transcript_test.exs` (3 passed)
- `mix test` (539 passed, 4 skipped, 13 excluded)
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`

Closes #55