### PR TITLE
feat(ingest): map stable authors to participants

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,15 @@ Message Flow:
 }
 ```
 
+### Inbound author identity
+
+Trusted application or runtime code supplies the normalized `Jido.Chat.Author.id`.
+Ingest uses that ID only when it creates an unbound participant. An existing
+external binding remains authoritative, including its participant ID and type.
+Adapters do not infer stable identity and ingest does not merge participants
+across bindings or platforms. Runtime messages keep role `:user`; author type
+(`:human`, `:agent`, or `:system`) is stored on the participant.
+
 ## Documentation
 
 Full documentation is available at [HexDocs](https://hexdocs.pm/jido_messaging).

--- a/lib/jido_messaging/ingest.ex
+++ b/lib/jido_messaging/ingest.ex
@@ -342,22 +342,51 @@ defmodule Jido.Messaging.Ingest do
   end
 
   defp resolve_participant(messaging_module, channel_type, bridge_id, incoming) do
-    external_id = to_string(incoming.external_user_id)
+    author = Map.get(incoming, :author)
+    external_id = first_present(Map.get(incoming, :external_user_id), author_value(author, :user_id))
+    username = first_present(author_value(author, :user_name), Map.get(incoming, :username))
+    display_name = first_present(author_value(author, :full_name), Map.get(incoming, :display_name))
+    email = author_value(author, :email)
 
-    participant_attrs = %{
-      type: :human,
-      identity: %{
-        username: Map.get(incoming, :username),
-        display_name: Map.get(incoming, :display_name)
+    identity = %{username: username, display_name: display_name}
+    identity = if blank_value?(email), do: identity, else: Map.put(identity, :email, email)
+
+    participant_attrs =
+      %{
+        type: author_type(author),
+        identity: identity
       }
-    }
+      |> maybe_put_stable_author_id(author_value(author, :id))
 
     messaging_module.get_or_create_participant_by_external_id(
       channel_type,
       bridge_id,
-      external_id,
+      to_string(external_id),
       participant_attrs
     )
+  end
+
+  defp author_value(author, key) when is_map(author), do: Map.get(author, key) || Map.get(author, Atom.to_string(key))
+  defp author_value(_author, _key), do: nil
+
+  defp first_present(value, fallback) do
+    if blank_value?(value), do: fallback, else: value
+  end
+
+  defp blank_value?(nil), do: true
+  defp blank_value?(value) when is_binary(value), do: String.trim(value) == ""
+  defp blank_value?(_value), do: false
+
+  defp maybe_put_stable_author_id(attrs, author_id) do
+    if blank_value?(author_id), do: attrs, else: Map.put(attrs, :id, author_id)
+  end
+
+  defp author_type(author) do
+    cond do
+      author_value(author, :is_system) == true -> :system
+      author_value(author, :is_bot) == true -> :agent
+      true -> :human
+    end
   end
 
   defp build_message(messaging_module, room, participant, thread, incoming, channel_type, bridge_id, opts) do
@@ -385,6 +414,13 @@ defmodule Jido.Messaging.Ingest do
   end
 
   defp build_msg_context(channel_module, bridge_id, incoming, room, participant, opts) do
+    incoming =
+      Map.put(
+        incoming,
+        :external_user_id,
+        first_present(Map.get(incoming, :external_user_id), author_value(Map.get(incoming, :author), :user_id))
+      )
+
     channel_module
     |> MsgContext.from_incoming(bridge_id, incoming)
     |> Normalizer.normalize(incoming, opts)

--- a/lib/jido_messaging/ingest.ex
+++ b/lib/jido_messaging/ingest.ex
@@ -209,6 +209,7 @@ defmodule Jido.Messaging.Ingest do
          incoming,
          opts
        ) do
+    incoming = Map.put(incoming, :external_user_id, external_user_id(incoming))
     raw_payload = incoming_raw_payload(incoming)
 
     with {:ok, verify_result} <-
@@ -421,8 +422,6 @@ defmodule Jido.Messaging.Ingest do
   end
 
   defp build_msg_context(channel_module, bridge_id, incoming, room, participant, opts) do
-    incoming = Map.put(incoming, :external_user_id, external_user_id(incoming))
-
     channel_module
     |> MsgContext.from_incoming(bridge_id, incoming)
     |> Normalizer.normalize(incoming, opts)

--- a/lib/jido_messaging/ingest.ex
+++ b/lib/jido_messaging/ingest.ex
@@ -343,7 +343,7 @@ defmodule Jido.Messaging.Ingest do
 
   defp resolve_participant(messaging_module, channel_type, bridge_id, incoming) do
     author = Map.get(incoming, :author)
-    external_id = first_present(Map.get(incoming, :external_user_id), author_value(author, :user_id))
+    external_id = external_user_id(incoming)
     username = first_present(author_value(author, :user_name), Map.get(incoming, :username))
     display_name = first_present(author_value(author, :full_name), Map.get(incoming, :display_name))
     email = author_value(author, :email)
@@ -368,6 +368,13 @@ defmodule Jido.Messaging.Ingest do
 
   defp author_value(author, key) when is_map(author), do: Map.get(author, key) || Map.get(author, Atom.to_string(key))
   defp author_value(_author, _key), do: nil
+
+  defp external_user_id(incoming) do
+    first_present(
+      Map.get(incoming, :external_user_id),
+      author_value(Map.get(incoming, :author), :user_id)
+    )
+  end
 
   defp first_present(value, fallback) do
     if blank_value?(value), do: fallback, else: value
@@ -414,12 +421,7 @@ defmodule Jido.Messaging.Ingest do
   end
 
   defp build_msg_context(channel_module, bridge_id, incoming, room, participant, opts) do
-    incoming =
-      Map.put(
-        incoming,
-        :external_user_id,
-        first_present(Map.get(incoming, :external_user_id), author_value(Map.get(incoming, :author), :user_id))
-      )
+    incoming = Map.put(incoming, :external_user_id, external_user_id(incoming))
 
     channel_module
     |> MsgContext.from_incoming(bridge_id, incoming)

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -225,6 +225,7 @@ defmodule Jido.Messaging.IngestTest do
       assert context.participant.id == "author_stable"
       assert message.sender_id == "author_stable"
       assert context.participant_id == "author_stable"
+      assert context.msg_context.external_user_id == "provider_user"
 
       assert context.participant.identity == %{
                username: "stable_user",
@@ -1086,6 +1087,24 @@ defmodule Jido.Messaging.IngestTest do
                TestMessaging.get_room_by_external_binding(:mock, "security_inst", "chat_security_deny")
 
       assert {:error, :not_found} = TestMessaging.get_message_by_external_id(:mock, "security_inst", 7002)
+    end
+
+    test "author-only identity rejects a conflicting sender claim before persistence" do
+      incoming = %{
+        external_room_id: "chat_security_author_deny",
+        author: %Jido.Chat.Author{id: "author_stable", user_id: "trusted_author", user_name: "trusted_author"},
+        text: "spoof attempt",
+        external_message_id: 7004,
+        raw: %{claimed_sender_id: "spoofed_user"}
+      }
+
+      assert {:error, {:security_denied, :verify, :sender_claim_mismatch, _description}} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "security_inst", incoming)
+
+      assert {:error, :not_found} =
+               TestMessaging.get_room_by_external_binding(:mock, "security_inst", "chat_security_author_deny")
+
+      assert {:error, :not_found} = TestMessaging.get_message_by_external_id(:mock, "security_inst", 7004)
     end
 
     test "security timeout policy deny is bounded and returns typed retry-class failure" do

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -204,7 +204,7 @@ defmodule Jido.Messaging.IngestTest do
     test "uses normalized author identity and stable id for participant, sender, and context" do
       incoming = %{
         external_room_id: "author_room",
-        author: %Jido.Chat.Author{
+        author: %{
           id: "author_stable",
           user_id: "provider_user",
           user_name: "stable_user",
@@ -240,7 +240,7 @@ defmodule Jido.Messaging.IngestTest do
       bot = %{
         external_room_id: "bot_room",
         external_user_id: "bot_provider",
-        author: %Jido.Chat.Author{id: "bot_stable", user_id: "bot_provider", user_name: "bot", is_bot: true},
+        author: %{id: "bot_stable", user_id: "bot_provider", user_name: "bot", is_bot: true},
         text: "Bot"
       }
 
@@ -253,7 +253,7 @@ defmodule Jido.Messaging.IngestTest do
       system = %{
         external_room_id: "system_room",
         external_user_id: "system_provider",
-        author: %Jido.Chat.Author{
+        author: %{
           id: "system_stable",
           user_id: "system_provider",
           user_name: "system",
@@ -274,7 +274,7 @@ defmodule Jido.Messaging.IngestTest do
       incoming = %{
         external_room_id: "blank_author_room",
         external_user_id: "blank_provider",
-        author: %Jido.Chat.Author{id: "  ", user_id: "blank_provider", user_name: "blank"},
+        author: %{id: "  ", user_id: "blank_provider", user_name: "blank"},
         text: "First"
       }
 
@@ -304,7 +304,7 @@ defmodule Jido.Messaging.IngestTest do
     test "nil author id keeps generated IDs and does not merge equal display names" do
       base = %{
         external_room_id: "same_name_room",
-        author: %Jido.Chat.Author{id: nil, user_id: "provider_one", user_name: "same", full_name: "Same Name"},
+        author: %{id: nil, user_id: "provider_one", user_name: "same", full_name: "Same Name"},
         text: "Same name"
       }
 
@@ -321,7 +321,7 @@ defmodule Jido.Messaging.IngestTest do
       second_input =
         base
         |> Map.put(:external_user_id, "provider_two")
-        |> Map.put(:author, %Jido.Chat.Author{
+        |> Map.put(:author, %{
           id: nil,
           user_id: "provider_two",
           user_name: "same",
@@ -337,7 +337,7 @@ defmodule Jido.Messaging.IngestTest do
       first = %{
         external_room_id: "conflict_room",
         external_user_id: "conflict_provider",
-        author: %Jido.Chat.Author{id: "original_stable", user_id: "conflict_provider", user_name: "original"},
+        author: %{id: "original_stable", user_id: "conflict_provider", user_name: "original"},
         text: "First",
         external_message_id: "conflict_first"
       }
@@ -346,7 +346,7 @@ defmodule Jido.Messaging.IngestTest do
 
       second = %{
         first
-        | author: %Jido.Chat.Author{id: "other_stable", user_id: "conflict_provider", user_name: "other", is_bot: true},
+        | author: %{id: "other_stable", user_id: "conflict_provider", user_name: "other", is_bot: true},
           text: "Second",
           external_message_id: "conflict_second"
       }
@@ -1092,7 +1092,7 @@ defmodule Jido.Messaging.IngestTest do
     test "author-only identity rejects a conflicting sender claim before persistence" do
       incoming = %{
         external_room_id: "chat_security_author_deny",
-        author: %Jido.Chat.Author{id: "author_stable", user_id: "trusted_author", user_name: "trusted_author"},
+        author: %{id: "author_stable", user_id: "trusted_author", user_name: "trusted_author"},
         text: "spoof attempt",
         external_message_id: 7004,
         raw: %{claimed_sender_id: "spoofed_user"}

--- a/test/jido_messaging/ingest_test.exs
+++ b/test/jido_messaging/ingest_test.exs
@@ -201,6 +201,163 @@ defmodule Jido.Messaging.IngestTest do
   end
 
   describe "ingest_incoming/4" do
+    test "uses normalized author identity and stable id for participant, sender, and context" do
+      incoming = %{
+        external_room_id: "author_room",
+        author: %Jido.Chat.Author{
+          id: "author_stable",
+          user_id: "provider_user",
+          user_name: "stable_user",
+          full_name: "Stable User",
+          email: "stable@example.com",
+          is_bot: false,
+          is_me: false,
+          is_system: false,
+          metadata: %{}
+        },
+        text: "Hello",
+        external_message_id: "author_message"
+      }
+
+      assert {:ok, message, context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "author_instance", incoming)
+
+      assert context.participant.id == "author_stable"
+      assert message.sender_id == "author_stable"
+      assert context.participant_id == "author_stable"
+
+      assert context.participant.identity == %{
+               username: "stable_user",
+               display_name: "Stable User",
+               email: "stable@example.com"
+             }
+
+      assert context.participant.type == :human
+    end
+
+    test "maps bot and system author classifications while keeping runtime role user" do
+      bot = %{
+        external_room_id: "bot_room",
+        external_user_id: "bot_provider",
+        author: %Jido.Chat.Author{id: "bot_stable", user_id: "bot_provider", user_name: "bot", is_bot: true},
+        text: "Bot"
+      }
+
+      assert {:ok, bot_message, bot_context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "bot_instance", bot)
+
+      assert bot_context.participant.type == :agent
+      assert bot_message.role == :user
+
+      system = %{
+        external_room_id: "system_room",
+        external_user_id: "system_provider",
+        author: %Jido.Chat.Author{
+          id: "system_stable",
+          user_id: "system_provider",
+          user_name: "system",
+          is_bot: true,
+          is_system: true
+        },
+        text: "System"
+      }
+
+      assert {:ok, system_message, system_context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "system_instance", system)
+
+      assert system_context.participant.type == :system
+      assert system_message.role == :user
+    end
+
+    test "keeps generated id and external binding when stable author id is blank" do
+      incoming = %{
+        external_room_id: "blank_author_room",
+        external_user_id: "blank_provider",
+        author: %Jido.Chat.Author{id: "  ", user_id: "blank_provider", user_name: "blank"},
+        text: "First"
+      }
+
+      assert {:ok, first, _} = Ingest.ingest_incoming(TestMessaging, MockChannel, "blank_instance", incoming)
+      assert is_binary(first.sender_id) and first.sender_id != ""
+      refute first.sender_id == "  "
+
+      incoming = Map.merge(incoming, %{text: "Second", external_message_id: "second"})
+      assert {:ok, second, _} = Ingest.ingest_incoming(TestMessaging, MockChannel, "blank_instance", incoming)
+      assert second.sender_id == first.sender_id
+    end
+
+    test "legacy top-level identity remains supported" do
+      incoming = %{
+        external_room_id: "legacy_author_room",
+        external_user_id: "legacy_provider",
+        username: "legacy_user",
+        display_name: "Legacy User",
+        text: "Legacy"
+      }
+
+      assert {:ok, message, context} = Ingest.ingest_incoming(TestMessaging, MockChannel, "legacy_instance", incoming)
+      assert message.sender_id == context.participant.id
+      assert context.participant.identity == %{username: "legacy_user", display_name: "Legacy User"}
+    end
+
+    test "nil author id keeps generated IDs and does not merge equal display names" do
+      base = %{
+        external_room_id: "same_name_room",
+        author: %Jido.Chat.Author{id: nil, user_id: "provider_one", user_name: "same", full_name: "Same Name"},
+        text: "Same name"
+      }
+
+      assert {:ok, first, _} =
+               Ingest.ingest_incoming(
+                 TestMessaging,
+                 MockChannel,
+                 "same_name_instance",
+                 Map.put(base, :external_user_id, "provider_one")
+               )
+
+      assert is_binary(first.sender_id) and first.sender_id != ""
+
+      second_input =
+        base
+        |> Map.put(:external_user_id, "provider_two")
+        |> Map.put(:author, %Jido.Chat.Author{
+          id: nil,
+          user_id: "provider_two",
+          user_name: "same",
+          full_name: "Same Name"
+        })
+        |> Map.put(:external_message_id, "same_name_second")
+
+      assert {:ok, second, _} = Ingest.ingest_incoming(TestMessaging, MockChannel, "same_name_instance", second_input)
+      assert second.sender_id != first.sender_id
+    end
+
+    test "existing external binding keeps original stable id and type" do
+      first = %{
+        external_room_id: "conflict_room",
+        external_user_id: "conflict_provider",
+        author: %Jido.Chat.Author{id: "original_stable", user_id: "conflict_provider", user_name: "original"},
+        text: "First",
+        external_message_id: "conflict_first"
+      }
+
+      assert {:ok, first_message, _} = Ingest.ingest_incoming(TestMessaging, MockChannel, "conflict_instance", first)
+
+      second = %{
+        first
+        | author: %Jido.Chat.Author{id: "other_stable", user_id: "conflict_provider", user_name: "other", is_bot: true},
+          text: "Second",
+          external_message_id: "conflict_second"
+      }
+
+      assert {:ok, second_message, second_context} =
+               Ingest.ingest_incoming(TestMessaging, MockChannel, "conflict_instance", second)
+
+      assert second_message.sender_id == first_message.sender_id
+      assert second_context.participant.id == "original_stable"
+      assert second_context.participant.type == :human
+    end
+
     test "creates room, participant, and message" do
       incoming = %{
         external_room_id: "chat_123",

--- a/test/jido_messaging/reply_mapping_test.exs
+++ b/test/jido_messaging/reply_mapping_test.exs
@@ -157,6 +157,7 @@ defmodule Jido.Messaging.ReplyMappingTest do
       {:ok, reply_msg, _ctx} = Ingest.ingest_incoming(TestMessaging, MockChannel, "inst_reply", incoming_reply)
 
       assert reply_msg.reply_to_id == parent_msg.id
+      assert reply_msg.external_reply_to_id == "parent_ext_123"
       assert reply_msg.external_id == "reply_ext_456"
     end
 
@@ -172,6 +173,7 @@ defmodule Jido.Messaging.ReplyMappingTest do
       {:ok, message, _ctx} = Ingest.ingest_incoming(TestMessaging, MockChannel, "inst_orphan", incoming)
 
       assert message.reply_to_id == nil
+      assert message.external_reply_to_id == "nonexistent_parent"
     end
 
     test "reply_to_id is nil when no external_reply_to_id provided" do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -6,6 +6,14 @@ This document provides guidelines for AI assistants (Claude, Cursor, etc.) when 
 
 Jido Messaging is part of the Jido ecosystem - a framework for building intelligent agent systems. It provides messaging and notification infrastructure.
 
+## Author Identity
+
+Trusted application or runtime resolvers supply stable `Author.id` values.
+Ingest uses the value only when creating an unbound participant. Existing
+external bindings remain authoritative. Adapters must not infer stable identity,
+and ingest must not merge or rebind participants across external bindings or
+platforms.
+
 ## Code Generation Rules
 
 1. **Always use conventional commits** - Follow `type(scope): description` format


### PR DESCRIPTION
## Summary

Issue 36 now reaches the messaging runtime after the core contract work in agentjido/jido_chat#46. This PR maps trusted author identity into the existing participant, sender, and message-context contracts.

- A nonblank `Author.id` seeds a new participant ID for an unbound provider identity.
- Existing external bindings remain authoritative. Ingest does not merge or rebind participants.
- Author names and email populate the existing participant identity map.
- Participant type uses `:system` before `:agent` before `:human`.
- Runtime messages keep `role: :user`, and both internal and external reply IDs remain available.
- Sender verification uses the same `Author.user_id` fallback as participant resolution.

Session-settled decisions carried from planning: participant creation reuses the existing binding contract; classification does not change runtime message roles; pairing and collision policy remain in issue 40.

## Dependency order

This PR depends on agentjido/jido_chat#46 and the core package release. After that release, refresh `mix.lock` to the released `jido_chat` version and run the direct runtime gates before this PR becomes ready for merge. No permanent path dependency is included.

## Validation

- Sibling-core validation: 543 tests passed, 4 skipped, and 13 excluded.
- `mix quality`: formatting, Credo, Dialyzer, and Doctor passed with the temporary sibling-core override.
- Isolated cross-package checks: 6 focused tests passed; 6 default tests passed and 9 live tests were excluded.
- Code review: complete (`20260820-182942-b9d21554`); the validated sender-verification finding was fixed and verified.

## Related

Depends on agentjido/jido_chat#46.

Related: agentjido/jido_chat#36

Participant pairing, rebinding, and stable-ID collision policy remain in agentjido/jido_chat#40.

## Post-Deploy Monitoring & Validation

- Search logs for `security_denied`, `sender_claim_mismatch`, participant-resolution failures, and ingest errors.
- Watch inbound ingest failures, sender-verification denials, and participant-creation error counts for 24 hours after release.
- Healthy signal: stable participant, sender, and context IDs agree, while provider bindings and legacy inputs continue to resolve.
- Failure signal: a new denial spike, participant-creation errors, or sender/context ID mismatch after consumers upgrade.
- Mitigation: omit `Author.id` to use generated participant IDs, or roll back to the prior runtime release.
- Owner: the package maintainer or release on-call.

## New concepts

### Identity seeding and binding authority

Stable identity seeds a participant only when no provider binding exists. After creation, the provider binding is the authority for later messages.

This order prevents a later payload from silently changing a participant ID or type. For example, the first message can create participant `person:42`; a later message on the same provider binding cannot replace it with `person:99`.

Do not use this rule to pair one stable ID across several providers. Pairing, collisions, and rebinding require an explicit policy and atomic persistence behavior.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
