### PR TITLE
feat(receipts): persist normalized read status

### DIFF
--- a/lib/jido_messaging.ex
+++ b/lib/jido_messaging.ex
@@ -182,6 +182,27 @@ defmodule Jido.Messaging do
       end
 
       @doc """
+      Mark a provider message as read and persist its normalized receipt.
+
+      ## Example
+
+          iex> defmodule ReceiptExample do
+          ...>   use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
+          ...> end
+          iex> function_exported?(ReceiptExample, :mark_message_as_read, 3)
+          true
+      """
+      def mark_message_as_read(message_id, participant_id, opts \\ []) do
+        Jido.Messaging.mark_message_as_read(
+          __MODULE__,
+          __jido_messaging__(:runtime),
+          message_id,
+          participant_id,
+          opts
+        )
+      end
+
+      @doc """
       List messages for a room.
 
       Use a message ID with `:before` or `:after` for cursor pagination. The
@@ -863,6 +884,19 @@ defmodule Jido.Messaging do
   def get_message(runtime, message_id) do
     {persistence, persistence_state} = Runtime.get_persistence(runtime)
     persistence.get_message(persistence_state, message_id)
+  end
+
+  @doc "Mark a provider message as read and persist its normalized receipt."
+  def mark_message_as_read(instance_module, runtime, message_id, participant_id, opts \\ [])
+      when is_atom(instance_module) and is_binary(message_id) and is_binary(participant_id) and
+             is_list(opts) do
+    Jido.Messaging.ReadReceipt.mark_as_read(
+      instance_module,
+      runtime,
+      message_id,
+      participant_id,
+      opts
+    )
   end
 
   @doc """

--- a/lib/jido_messaging/adapter_bridge.ex
+++ b/lib/jido_messaging/adapter_bridge.ex
@@ -78,6 +78,13 @@ defmodule Jido.Messaging.AdapterBridge do
     end
   end
 
+  @doc "Marks a provider message as read through the canonical adapter boundary."
+  @spec mark_as_read(module(), term(), term(), keyword()) :: :ok | {:error, term()}
+  def mark_as_read(adapter_module, external_room_id, external_message_id, opts \\ [])
+      when is_atom(adapter_module) and is_list(opts) do
+    Adapter.mark_as_read(adapter_module, external_room_id, external_message_id, opts)
+  end
+
   @doc """
   Sends media payload through the canonical adapter boundary.
 

--- a/lib/jido_messaging/persistence.ex
+++ b/lib/jido_messaging/persistence.ex
@@ -92,6 +92,10 @@ defmodule Jido.Messaging.Persistence do
               opts :: keyword()
             ) :: {:ok, [Message.t()]} | {:error, term()}
 
+  @doc "Atomically add a provider-confirmed read receipt to a message"
+  @callback mark_message_read(state, message_id, participant_id, receipt :: map()) ::
+              {:ok, Message.t(), :updated | :unchanged} | {:error, term()}
+
   # Thread operations
   @doc "Save a thread"
   @callback save_thread(state, Thread.t()) :: {:ok, Thread.t()} | {:error, term()}
@@ -255,7 +259,8 @@ defmodule Jido.Messaging.Persistence do
                       bind_participant_external_id: 5,
                       save_ingress_subscription: 2,
                       list_ingress_subscriptions: 3,
-                      delete_ingress_subscription: 3
+                      delete_ingress_subscription: 3,
+                      mark_message_read: 4
 
   @doc "Persist routing policy."
   @callback save_routing_policy(state, RoutingPolicy.t()) :: {:ok, RoutingPolicy.t()} | {:error, term()}

--- a/lib/jido_messaging/persistence/ets.ex
+++ b/lib/jido_messaging/persistence/ets.ex
@@ -292,6 +292,16 @@ defmodule Jido.Messaging.Persistence.ETS do
     Jido.Messaging.Transcript.paginate(messages, opts)
   end
 
+  @impl true
+  def mark_message_read(state, message_id, participant_id, receipt) do
+    # Global lock IDs are {resource, requester}; the shared resource serializes callers.
+    lock_id = {{__MODULE__, state.messages, message_id}, self()}
+
+    :global.trans(lock_id, fn ->
+      update_message_receipt(state.messages, message_id, participant_id, receipt)
+    end)
+  end
+
   # Thread operations
 
   @impl true
@@ -829,6 +839,23 @@ defmodule Jido.Messaging.Persistence.ETS do
        when is_binary(thread_id) do
     true = :ets.insert(state.thread_messages, {thread_id, message_id})
     :ok
+  end
+
+  defp update_message_receipt(table, message_id, participant_id, receipt) do
+    case :ets.lookup(table, message_id) do
+      [{^message_id, message}] ->
+        case Jido.Messaging.ReadReceipt.apply_to_message(message, participant_id, receipt) do
+          {updated, :updated} ->
+            true = :ets.insert(table, {message_id, updated})
+            {:ok, updated, :updated}
+
+          {unchanged, :unchanged} ->
+            {:ok, unchanged, :unchanged}
+        end
+
+      [] ->
+        {:error, :not_found}
+    end
   end
 
   defp maybe_delete_thread_message(_state, %Message{thread_id: nil}), do: :ok

--- a/lib/jido_messaging/persistence/sqlite.ex
+++ b/lib/jido_messaging/persistence/sqlite.ex
@@ -292,6 +292,19 @@ defmodule Jido.Messaging.Persistence.SQLite do
     end
   end
 
+  @impl true
+  def mark_message_read(state, message_id, participant_id, receipt) do
+    with {:ok, message, payload} <- fetch_message_payload(state, message_id) do
+      case Jido.Messaging.ReadReceipt.apply_to_message(message, participant_id, receipt) do
+        {updated, :updated} ->
+          compare_and_swap_message(state, message_id, participant_id, receipt, payload, updated)
+
+        {unchanged, :unchanged} ->
+          {:ok, unchanged, :unchanged}
+      end
+    end
+  end
+
   defp query_participant_page(db, where, params, direction, limit, reverse?) do
     limit_param = length(params) + 1
 
@@ -1356,6 +1369,47 @@ defmodule Jido.Messaging.Persistence.SQLite do
           end
         end
       end)
+    end
+  end
+
+  defp fetch_message_payload(state, message_id) do
+    with {:ok, rows} <-
+           query_all(
+             state.db,
+             "SELECT payload FROM #{@table} WHERE instance_id = ?1 AND kind = 'message' AND id = ?2 LIMIT 1",
+             [state.instance_id, message_id]
+           ) do
+      case rows do
+        [[payload]] -> {:ok, :erlang.binary_to_term(payload), payload}
+        [] -> {:error, :not_found}
+      end
+    end
+  end
+
+  defp compare_and_swap_message(state, message_id, participant_id, receipt, old_payload, updated) do
+    with {:ok, rows} <-
+           query_all(
+             state.db,
+             """
+             UPDATE #{@table}
+             SET payload = ?1
+             WHERE instance_id = ?2 AND kind = 'message' AND id = ?3 AND payload = ?4
+             RETURNING id
+             """,
+             [
+               {:blob, :erlang.term_to_binary(updated)},
+               state.instance_id,
+               message_id,
+               {:blob, old_payload}
+             ]
+           ) do
+      case rows do
+        [[_payload]] ->
+          {:ok, updated, :updated}
+
+        [] ->
+          mark_message_read(state, message_id, participant_id, receipt)
+      end
     end
   end
 

--- a/lib/jido_messaging/read_receipt.ex
+++ b/lib/jido_messaging/read_receipt.ex
@@ -1,0 +1,225 @@
+defmodule Jido.Messaging.ReadReceipt do
+  @moduledoc """
+  Maps a provider-confirmed read operation to a persisted runtime message.
+
+  The provider operation completes before persistence changes. A provider
+  failure or unsupported adapter therefore leaves the local message unchanged.
+  """
+
+  alias Jido.Messaging.{
+    AdapterBridge,
+    BridgeConfig,
+    ConfigStore,
+    Message,
+    RoomBinding,
+    Runtime,
+    SecretResolver
+  }
+
+  @type persistence_result :: {:ok, Message.t(), :updated | :unchanged} | {:error, term()}
+
+  @doc "Marks a provider message as read and persists the normalized receipt."
+  @spec mark_as_read(module(), GenServer.server(), String.t(), String.t(), keyword()) ::
+          {:ok, Message.t()} | {:error, term()}
+  def mark_as_read(instance_module, runtime, message_id, participant_id, opts \\ [])
+      when is_atom(instance_module) and is_binary(message_id) and is_binary(participant_id) and
+             is_list(opts) do
+    {persistence, persistence_state} = Runtime.get_persistence(runtime)
+
+    with {:ok, message} <- persistence.get_message(persistence_state, message_id),
+         {:ok, bridge_id} <- resolve_bridge_id(message, opts),
+         :miss <- provider_receipt_status(message, participant_id, bridge_id),
+         {:ok, read_at} <- resolve_read_at(opts),
+         {:ok, config} <- fetch_bridge(instance_module, bridge_id),
+         {:ok, external_room_id} <- resolve_external_room_id(persistence, persistence_state, message, bridge_id, opts),
+         {:ok, external_message_id} <- resolve_external_message_id(message, opts),
+         {:ok, adapter_opts} <- adapter_opts(instance_module, config, message, participant_id, bridge_id, opts),
+         :ok <-
+           AdapterBridge.mark_as_read(
+             config.adapter_module,
+             external_room_id,
+             external_message_id,
+             adapter_opts
+           ),
+         {:ok, updated, _change} <-
+           persist(
+             persistence,
+             persistence_state,
+             message_id,
+             participant_id,
+             receipt(bridge_id, external_message_id, read_at)
+           ) do
+      {:ok, updated}
+    else
+      {:already_read, %Message{} = message} -> {:ok, message}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc false
+  @spec apply_to_message(Message.t(), String.t(), map()) ::
+          {Message.t(), :updated | :unchanged}
+  def apply_to_message(%Message{} = message, participant_id, receipt)
+      when is_binary(participant_id) and is_map(receipt) do
+    bridge_id = Map.fetch!(receipt, :bridge_id)
+    read_at = Map.fetch!(receipt, :read_at)
+    existing_receipt = Map.get(message.receipts || %{}, participant_id, %{})
+    provider_reads = Map.get(existing_receipt, :provider_reads, %{})
+
+    if Map.has_key?(provider_reads, bridge_id) do
+      {message, :unchanged}
+    else
+      provider_read = %{
+        external_message_id: Map.fetch!(receipt, :external_message_id),
+        read_at: read_at
+      }
+
+      updated_receipt =
+        existing_receipt
+        |> Map.put_new(:delivered_at, read_at)
+        |> Map.put_new(:read_at, read_at)
+        |> Map.put(:provider_reads, Map.put(provider_reads, bridge_id, provider_read))
+
+      updated = %{
+        message
+        | status: :read,
+          receipts: Map.put(message.receipts || %{}, participant_id, updated_receipt),
+          updated_at: read_at
+      }
+
+      {updated, :updated}
+    end
+  end
+
+  defp provider_receipt_status(message, participant_id, bridge_id) do
+    provider_reads =
+      message.receipts
+      |> Map.get(participant_id, %{})
+      |> Map.get(:provider_reads, %{})
+
+    if Map.has_key?(provider_reads, bridge_id),
+      do: {:already_read, message},
+      else: :miss
+  end
+
+  defp fetch_bridge(instance_module, bridge_id) do
+    case ConfigStore.get_bridge_config(instance_module, bridge_id) do
+      {:ok, %BridgeConfig{enabled: true} = config} -> {:ok, config}
+      {:ok, %BridgeConfig{enabled: false}} -> {:error, :bridge_disabled}
+      {:error, :not_found} -> {:error, :bridge_not_found}
+    end
+  end
+
+  defp resolve_bridge_id(message, opts) do
+    case opts[:bridge_id] || metadata_value(message.metadata, :bridge_id) do
+      bridge_id when is_binary(bridge_id) and bridge_id != "" -> {:ok, bridge_id}
+      bridge_id when not is_nil(bridge_id) -> {:ok, to_string(bridge_id)}
+      _missing -> {:error, :missing_bridge_id}
+    end
+  end
+
+  defp resolve_external_room_id(persistence, state, message, bridge_id, opts) do
+    direct = opts[:external_room_id] || message.delivery_external_room_id
+
+    if present?(direct) do
+      {:ok, direct}
+    else
+      with {:ok, bindings} <- persistence.list_room_bindings(state, message.room_id) do
+        case Enum.find(bindings, &match?(%RoomBinding{bridge_id: ^bridge_id}, &1)) do
+          %RoomBinding{} = binding ->
+            {:ok, binding.external_room_id}
+
+          nil ->
+            external_room_id_from_room(persistence, state, message.room_id, bridge_id)
+        end
+      end
+    end
+  end
+
+  defp external_room_id_from_room(persistence, state, room_id, bridge_id) do
+    with {:ok, room} <- persistence.get_room(state, room_id),
+         external_room_id when not is_nil(external_room_id) <-
+           find_external_room_id(room.external_bindings || %{}, bridge_id) do
+      {:ok, external_room_id}
+    else
+      nil -> {:error, :missing_external_room_id}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp find_external_room_id(external_bindings, bridge_id) do
+    Enum.find_value(external_bindings, fn {_channel, bridge_bindings} ->
+      Map.get(bridge_bindings, bridge_id) || Map.get(bridge_bindings, to_string(bridge_id))
+    end)
+  end
+
+  defp resolve_external_message_id(message, opts) do
+    case opts[:external_message_id] || message.external_id do
+      nil -> {:error, :missing_external_message_id}
+      value -> {:ok, value}
+    end
+  end
+
+  defp adapter_opts(instance_module, config, message, participant_id, bridge_id, opts) do
+    base_opts =
+      config.opts
+      |> Enum.reduce([], fn
+        {key, value}, acc when is_atom(key) -> Keyword.put(acc, key, value)
+        _entry, acc -> acc
+      end)
+      |> Keyword.merge(Keyword.get(opts, :adapter_opts, []))
+
+    with {:ok, adapter_opts} <-
+           SecretResolver.adapter_opts_for_config(instance_module, config, :mark_as_read, base_opts) do
+      {:ok,
+       adapter_opts
+       |> Keyword.put(:participant_id, participant_id)
+       |> Keyword.put(:local_message_id, message.id)
+       |> Keyword.put(:bridge_id, bridge_id)}
+    end
+  end
+
+  defp receipt(bridge_id, external_message_id, read_at) do
+    %{
+      bridge_id: bridge_id,
+      external_message_id: external_message_id,
+      read_at: read_at
+    }
+  end
+
+  defp resolve_read_at(opts) do
+    case Keyword.fetch(opts, :read_at) do
+      {:ok, %DateTime{} = read_at} -> {:ok, read_at}
+      {:ok, _invalid} -> {:error, :invalid_read_at}
+      :error -> {:ok, DateTime.utc_now()}
+    end
+  end
+
+  defp persist(persistence, state, message_id, participant_id, receipt) do
+    if function_exported?(persistence, :mark_message_read, 4) do
+      persistence.mark_message_read(state, message_id, participant_id, receipt)
+    else
+      persist_with_fallback(persistence, state, message_id, participant_id, receipt)
+    end
+  end
+
+  defp persist_with_fallback(persistence, state, message_id, participant_id, receipt) do
+    with {:ok, message} <- persistence.get_message(state, message_id) do
+      case apply_to_message(message, participant_id, receipt) do
+        {updated, :updated} ->
+          with {:ok, saved} <- persistence.save_message(state, updated) do
+            {:ok, saved, :updated}
+          end
+
+        {unchanged, :unchanged} ->
+          {:ok, unchanged, :unchanged}
+      end
+    end
+  end
+
+  defp metadata_value(metadata, key) do
+    Map.get(metadata || %{}, key) || Map.get(metadata || %{}, Atom.to_string(key))
+  end
+
+  defp present?(value), do: not is_nil(value) and value != ""
+end

--- a/test/jido_messaging/read_receipt_doctest_test.exs
+++ b/test/jido_messaging/read_receipt_doctest_test.exs
@@ -1,0 +1,5 @@
+defmodule Jido.Messaging.ReadReceiptDoctestTest do
+  use ExUnit.Case, async: true
+
+  doctest Jido.Messaging.ReadReceiptDoctestExample
+end

--- a/test/jido_messaging/read_receipt_test.exs
+++ b/test/jido_messaging/read_receipt_test.exs
@@ -1,0 +1,369 @@
+defmodule Jido.Messaging.ReadReceiptTest do
+  use ExUnit.Case, async: false
+
+  alias Exqlite.Sqlite3
+  alias Jido.Messaging.Message
+  alias Jido.Messaging.Persistence.{ETS, SQLite}
+
+  defmodule NativeAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :receipt_test
+
+    @impl true
+    def send_message(_external_room_id, _text, _opts), do: {:ok, %{message_id: "sent-1"}}
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def mark_as_read(external_room_id, external_message_id, opts) do
+      send(opts[:notify_pid], {:provider_read, external_room_id, external_message_id, opts})
+      :ok
+    end
+  end
+
+  defmodule Resolver do
+    @behaviour Jido.Messaging.SecretResolver
+
+    @impl true
+    def resolve(:receipt_token, context) do
+      send(Application.fetch_env!(Resolver, :notify_pid), {:resolved_secret, context})
+      {:ok, "resolved-receipt-token"}
+    end
+
+    def resolve(:failing_receipt_token, _context), do: {:error, :unavailable}
+  end
+
+  defmodule FailingAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :receipt_failure
+
+    @impl true
+    def send_message(_external_room_id, _text, _opts), do: {:ok, %{message_id: "sent-1"}}
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def mark_as_read(_external_room_id, _external_message_id, _opts),
+      do: {:error, :provider_unavailable}
+  end
+
+  defmodule UnsupportedAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :receipt_unsupported
+
+    @impl true
+    def send_message(_external_room_id, _text, _opts), do: {:ok, %{message_id: "sent-1"}}
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+  end
+
+  defmodule ETSMessaging do
+    use Jido.Messaging, persistence: ETS
+  end
+
+  describe "provider read mapping" do
+    setup do
+      start_supervised!(ETSMessaging)
+
+      {:ok, room} =
+        ETSMessaging.get_or_create_room_by_external_binding(
+          :receipt_test,
+          "bridge-1",
+          "provider-room-1",
+          %{id: "room-1", type: :channel, name: "Receipt test"}
+        )
+
+      {:ok, message} =
+        ETSMessaging.save_message(%{
+          id: "message-1",
+          room_id: room.id,
+          sender_id: "sender-1",
+          role: :user,
+          content: [%{type: :text, text: "hello"}],
+          external_id: "provider-message-1",
+          status: :sent,
+          metadata: %{channel: :receipt_test, bridge_id: "bridge-1"}
+        })
+
+      %{message: message}
+    end
+
+    test "calls the provider before it persists one stable read receipt", %{message: message} do
+      read_at = ~U[2026-08-20 12:00:00Z]
+
+      assert {:ok, config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: NativeAdapter,
+                 opts: %{notify_pid: self(), tenant: "tenant-1"}
+               })
+
+      assert {:ok, read} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1", read_at: read_at)
+
+      assert_receive {:provider_read, "provider-room-1", "provider-message-1", provider_opts}
+      assert provider_opts[:credentials] == config.credentials
+      assert provider_opts[:tenant] == "tenant-1"
+      assert provider_opts[:participant_id] == "reader-1"
+
+      assert read.status == :read
+      assert read.receipts["reader-1"].delivered_at == read_at
+      assert read.receipts["reader-1"].read_at == read_at
+
+      assert read.receipts["reader-1"].provider_reads["bridge-1"] == %{
+               external_message_id: "provider-message-1",
+               read_at: read_at
+             }
+
+      assert {:ok, replayed} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1", read_at: DateTime.add(read_at, 60))
+
+      assert replayed == read
+      refute_receive {:provider_read, _, _, _}
+      assert {:ok, ^read} = ETSMessaging.get_message(message.id)
+    end
+
+    test "resolves bridge secrets for mark_as_read before calling the provider", %{message: message} do
+      original_resolver = Application.get_env(ETSMessaging, :secret_resolver)
+      original_notify_pid = Application.get_env(Resolver, :notify_pid)
+      Application.put_env(ETSMessaging, :secret_resolver, Resolver)
+      Application.put_env(Resolver, :notify_pid, self())
+
+      on_exit(fn ->
+        restore_env(ETSMessaging, :secret_resolver, original_resolver)
+        restore_env(Resolver, :notify_pid, original_notify_pid)
+      end)
+
+      assert {:ok, _config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: NativeAdapter,
+                 secret_refs: %{token: :receipt_token},
+                 opts: %{notify_pid: self()}
+               })
+
+      assert {:ok, _read} = ETSMessaging.mark_message_as_read(message.id, "reader-1")
+
+      assert_receive {:resolved_secret,
+                      %{operation: :mark_as_read, bridge_id: "bridge-1", adapter_module: NativeAdapter}}
+
+      assert_receive {:provider_read, "provider-room-1", "provider-message-1", provider_opts}
+      assert provider_opts[:credentials] == %{token: "resolved-receipt-token"}
+      assert provider_opts[:participant_id] == "reader-1"
+      assert provider_opts[:local_message_id] == message.id
+    end
+
+    test "does not call the provider or persist when secret resolution fails", %{message: message} do
+      original_resolver = Application.get_env(ETSMessaging, :secret_resolver)
+      Application.put_env(ETSMessaging, :secret_resolver, Resolver)
+      on_exit(fn -> restore_env(ETSMessaging, :secret_resolver, original_resolver) end)
+
+      assert {:ok, _config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: NativeAdapter,
+                 secret_refs: %{token: :failing_receipt_token},
+                 opts: %{notify_pid: self()}
+               })
+
+      assert {:error, {:secret_resolution_failed, "bridge-1", :token, :resolver_failed}} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1")
+
+      refute_receive {:provider_read, _, _, _}
+      assert {:ok, unchanged} = ETSMessaging.get_message(message.id)
+      assert unchanged.receipts == %{}
+    end
+
+    test "does not persist a receipt when the provider fails", %{message: message} do
+      assert {:ok, _config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: FailingAdapter
+               })
+
+      assert {:error, :provider_unavailable} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1")
+
+      assert {:ok, unchanged} = ETSMessaging.get_message(message.id)
+      assert unchanged.status == :sent
+      assert unchanged.receipts == %{}
+    end
+
+    test "does not claim a receipt for an unsupported adapter", %{message: message} do
+      assert {:ok, _config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: UnsupportedAdapter
+               })
+
+      assert {:error, :unsupported} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1")
+
+      assert {:ok, unchanged} = ETSMessaging.get_message(message.id)
+      assert unchanged.status == :sent
+      assert unchanged.receipts == %{}
+    end
+
+    test "rejects an invalid timestamp before it calls the provider", %{message: message} do
+      assert {:ok, _config} =
+               ETSMessaging.put_bridge_config(%{
+                 id: "bridge-1",
+                 adapter_module: NativeAdapter,
+                 opts: %{notify_pid: self()}
+               })
+
+      assert {:error, :invalid_read_at} =
+               ETSMessaging.mark_message_as_read(message.id, "reader-1", read_at: "not-a-date")
+
+      refute_receive {:provider_read, _, _, _}
+      assert {:ok, unchanged} = ETSMessaging.get_message(message.id)
+      assert unchanged.receipts == %{}
+    end
+  end
+
+  describe "persistence parity" do
+    test "ETS applies duplicate receipt updates once" do
+      {:ok, state} = ETS.init([])
+      message = receipt_message("ets-message")
+      {:ok, ^message} = ETS.save_message(state, message)
+
+      first = receipt("bridge-1", ~U[2026-08-20 12:00:00Z])
+      replay = receipt("bridge-1", ~U[2026-08-20 13:00:00Z])
+
+      assert {:ok, updated, :updated} =
+               ETS.mark_message_read(state, message.id, "reader-1", first)
+
+      assert {:ok, ^updated, :unchanged} =
+               ETS.mark_message_read(state, message.id, "reader-1", replay)
+
+      assert updated.receipts["reader-1"].read_at == first.read_at
+    end
+
+    test "SQLite applies duplicate receipt updates once and keeps them after restart" do
+      path = Path.join(System.tmp_dir!(), "jido-messaging-receipt-#{System.unique_integer([:positive])}.sqlite3")
+      on_exit(fn -> File.rm(path) end)
+
+      {:ok, state} = SQLite.init(path: path)
+      message = receipt_message("sqlite-message")
+      {:ok, ^message} = SQLite.save_message(state, message)
+
+      first = receipt("bridge-1", ~U[2026-08-20 12:00:00Z])
+      replay = receipt("bridge-1", ~U[2026-08-20 13:00:00Z])
+
+      assert {:ok, updated, :updated} =
+               SQLite.mark_message_read(state, message.id, "reader-1", first)
+
+      assert {:ok, ^updated, :unchanged} =
+               SQLite.mark_message_read(state, message.id, "reader-1", replay)
+
+      :ok = Sqlite3.close(state.db)
+      {:ok, restarted} = SQLite.init(path: path)
+      assert {:ok, ^updated} = SQLite.get_message(restarted, message.id)
+      :ok = Sqlite3.close(restarted.db)
+    end
+
+    test "SQLite keeps receipts isolated when instances use the same message ID" do
+      path =
+        Path.join(System.tmp_dir!(), "jido-messaging-receipt-isolation-#{System.unique_integer([:positive])}.sqlite3")
+
+      on_exit(fn -> File.rm(path) end)
+
+      {:ok, first_instance} = SQLite.init(path: path, instance_id: "first")
+      {:ok, second_instance} = SQLite.init(path: path, instance_id: "second")
+      message = receipt_message("shared-message")
+      {:ok, ^message} = SQLite.save_message(first_instance, message)
+      {:ok, ^message} = SQLite.save_message(second_instance, message)
+
+      first_receipt = receipt("bridge-first", ~U[2026-08-20 12:00:00Z])
+      second_receipt = receipt("bridge-second", ~U[2026-08-20 13:00:00Z])
+
+      assert {:ok, first_updated, :updated} =
+               SQLite.mark_message_read(first_instance, message.id, "reader-1", first_receipt)
+
+      assert {:ok, second_updated, :updated} =
+               SQLite.mark_message_read(second_instance, message.id, "reader-2", second_receipt)
+
+      assert first_updated.receipts == %{"reader-1" => first_updated.receipts["reader-1"]}
+      assert second_updated.receipts == %{"reader-2" => second_updated.receipts["reader-2"]}
+      assert {:ok, ^first_updated} = SQLite.get_message(first_instance, message.id)
+      assert {:ok, ^second_updated} = SQLite.get_message(second_instance, message.id)
+
+      :ok = Sqlite3.close(first_instance.db)
+      :ok = Sqlite3.close(second_instance.db)
+    end
+
+    test "ETS keeps one receipt during concurrent duplicate updates" do
+      {:ok, state} = ETS.init([])
+      message = receipt_message("ets-concurrent-message")
+      {:ok, ^message} = ETS.save_message(state, message)
+
+      results = concurrent_receipts(ETS, state, message.id)
+
+      assert Enum.count(results, &match?({:ok, _message, :updated}, &1)) == 1
+      assert Enum.count(results, &match?({:ok, _message, :unchanged}, &1)) == 7
+    end
+
+    test "SQLite keeps one receipt during concurrent duplicate updates" do
+      path = Path.join(System.tmp_dir!(), "jido-messaging-receipt-race-#{System.unique_integer([:positive])}.sqlite3")
+      on_exit(fn -> File.rm(path) end)
+
+      {:ok, state} = SQLite.init(path: path)
+      message = receipt_message("sqlite-concurrent-message")
+      {:ok, ^message} = SQLite.save_message(state, message)
+
+      results = concurrent_receipts(SQLite, state, message.id)
+
+      assert Enum.count(results, &match?({:ok, _message, :updated}, &1)) == 1
+      assert Enum.count(results, &match?({:ok, _message, :unchanged}, &1)) == 7
+      :ok = Sqlite3.close(state.db)
+    end
+  end
+
+  defp receipt_message(id) do
+    Message.new(%{
+      id: id,
+      room_id: "room-1",
+      sender_id: "sender-1",
+      role: :user,
+      content: [],
+      status: :sent
+    })
+  end
+
+  defp receipt(bridge_id, read_at) do
+    %{
+      bridge_id: bridge_id,
+      external_message_id: "provider-message-1",
+      read_at: read_at
+    }
+  end
+
+  defp concurrent_receipts(persistence, state, message_id) do
+    1..8
+    |> Task.async_stream(
+      fn offset ->
+        persistence.mark_message_read(
+          state,
+          message_id,
+          "reader-1",
+          receipt("bridge-1", DateTime.add(~U[2026-08-20 12:00:00Z], offset))
+        )
+      end,
+      max_concurrency: 8,
+      ordered: false
+    )
+    |> Enum.map(fn {:ok, result} -> result end)
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+end

--- a/test/support/read_receipt_doctest_example.ex
+++ b/test/support/read_receipt_doctest_example.ex
@@ -1,0 +1,5 @@
+defmodule Jido.Messaging.ReadReceiptDoctestExample do
+  @moduledoc false
+
+  use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
+end


### PR DESCRIPTION
## Summary

- mark provider messages as read through the configured adapter
- persist normalized read status and participant receipt data
- keep ETS and SQLite behavior idempotent and equivalent

## Implementation

- resolve the message, bridge, external room ID, and provider message ID before the provider call
- resolve bridge secrets through the approved `SecretResolver` path
- persist one normalized receipt only after provider success
- scope SQLite reads and compare-and-swap writes to the runtime instance
- provide a persistence fallback for adapters without the optimized receipt callback
- add public generated-instance API documentation and a doctest

## Validation

- focused receipt tests — 12 passed, including 1 doctest
- persistence tests — 48 passed
- full non-live suite — 620 passed, 4 skipped, 13 excluded
- format and Credo passed
- Dialyzer reported 0 errors
- `git diff --check` passed

`mix quality` reaches Doctor and then fails on two unchanged `origin/main` modules: `Jido.Messaging.Transcript` and `Jido.Messaging.Test.PersistenceConformanceFactory`.

## Dependency

This PR depends on the resource and read-receipt contracts in agentjido/jido_chat#50. Keep it as a draft until that core change is released and the Hex dependency can be updated.

Related: agentjido/jido_chat#38

## Post-Deploy Monitoring & Validation

- update to the released core version and run the direct messaging suite
- test the same receipt twice in ETS and SQLite and confirm one stored receipt
- test two runtime instances with the same local message ID in one SQLite database
- test a bridge that uses `secret_refs` and confirm no raw credentials are persisted
- watch for cross-instance receipt changes, provider calls without resolved secrets, repeated receipt entries, or provider success followed by persistence failure
- hold the messaging release if any of these signals occur

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
