### PR TITLE
feat(actions): add scoped chat operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,70 @@ session disconnects. The helper emits `jido.messaging.room.participant_joined`,
 `jido.messaging.room.participant_left`, and
 `jido.messaging.participant.presence_changed` signals.
 
+### Scoped Chat Actions
+
+`Jido.Messaging.ChatActions` provides reusable `Jido.Action` modules for chat
+reads, messages, moderation, typing, direct messages, and provider
+subscriptions. It filters each set with the resolved adapter capability matrix.
+
+```elixir
+alias Jido.Chat.MessagingTarget
+alias Jido.Messaging.ChatActions
+alias Jido.Messaging.ChatActions.{Policy, Scope}
+
+target =
+  MessagingTarget.for_thread("channel-123", "thread-456",
+    bridge_id: "slack-main",
+    channel_type: :slack
+  )
+
+scope =
+  Scope.thread("slack-main", :slack, "channel-123", "thread-456",
+    actor_id: "participant-789"
+  )
+
+# Visible writes need approval unless a narrow rule allows them.
+policy =
+  Policy.allow([:post_message],
+    actor: "participant-789",
+    channel: "channel-123",
+    thread: "thread-456"
+  )
+
+action_context =
+  ChatActions.context(MyApp.Messaging, %{
+    scope: scope,
+    policy: policy,
+    actor_id: "participant-789"
+  })
+
+{:ok, tools} = ChatActions.actions_for(MyApp.Messaging, target, :messenger)
+
+{:ok, %{status: :ok, data: response}} =
+  Jido.Exec.run(
+    Jido.Messaging.ChatActions.Messenger.PostMessage,
+    %{target: Map.from_struct(target), text: "Hello"},
+    action_context
+  )
+```
+
+Named presets are `:reader`, `:messenger`, `:moderator`, and `:all`. You can
+also pass a custom list of action modules to `actions_for/3`. Unsupported
+operations return `status: :error` before an adapter call. Out-of-scope work
+returns `status: :denied`. A visible write that has no matching allow rule
+returns `status: :approval_required` with audit context.
+
+Use `Scope.channel/4`, `Scope.thread/5`, or `Scope.strict_thread/5` for normal
+conversation work. Strict-thread scope does not permit its parent channel or a
+sibling thread. Unbounded reads, direct messages, and subscription control use
+an explicit `Scope.workspace/2`. `ChatActions.context/3` can infer a channel or
+thread scope from a normalized active message context.
+
+Scopes and policies support `to_map/1` and `from_map/1` for storage or job
+queues. Pass the restored values in Jido Action context. `Jido.Exec.run_async/4`
+preserves this context. Provider credentials and clients stay in trusted bridge
+configuration. They do not appear in action input or output schemas.
+
 ## Adapter Integration (Telegram + Discord)
 
 `jido_messaging` no longer ships in-package Telegram/Discord handlers.  

--- a/lib/jido_messaging/chat_actions.ex
+++ b/lib/jido_messaging/chat_actions.ex
@@ -1,0 +1,129 @@
+defmodule Jido.Messaging.ChatActions do
+  @moduledoc """
+  Capability-scoped `Jido.Action` sets for normalized chat operations.
+
+  The action input schemas contain only canonical targets and operation data.
+  Adapter modules, credentials, and provider clients stay in trusted runtime
+  context and bridge configuration.
+  """
+
+  alias Jido.Messaging.ChatActions.Executor
+  alias Jido.Messaging.ChatActions.Messenger
+  alias Jido.Messaging.ChatActions.Moderator
+  alias Jido.Messaging.ChatActions.Policy
+  alias Jido.Messaging.ChatActions.Reader
+  alias Jido.Messaging.ChatActions.Resolver
+  alias Jido.Messaging.ChatActions.Scope
+
+  @reader [
+    Reader.FetchMessage,
+    Reader.FetchChannelMessages,
+    Reader.FetchThread,
+    Reader.FetchThreadMessages,
+    Reader.ListThreads,
+    Reader.LookupParticipant,
+    Reader.LookupUser,
+    Reader.FetchChannelMetadata
+  ]
+
+  @messenger [
+    Messenger.PostMessage,
+    Messenger.PostChannelMessage,
+    Messenger.SendDirectMessage,
+    Messenger.StartTyping
+  ]
+
+  @moderator [
+    Moderator.EditMessage,
+    Moderator.DeleteMessage,
+    Moderator.AddReaction,
+    Moderator.RemoveReaction,
+    Moderator.EnsureSubscription,
+    Moderator.ListSubscriptions,
+    Moderator.DeleteSubscription
+  ]
+
+  @all @reader ++ @messenger ++ @moderator
+
+  @type preset :: :reader | :messenger | :moderator | :all
+
+  @doc "Returns all modules in a named preset without adapter filtering."
+  @spec preset(preset()) :: [module()]
+  def preset(:reader), do: @reader
+  def preset(:messenger), do: @messenger
+  def preset(:moderator), do: @moderator
+  def preset(:all), do: @all
+
+  @doc "Builds an action list from a preset or custom list and adapter capabilities."
+  @spec actions_for(module(), Jido.Chat.MessagingTarget.t() | map(), preset() | [module()]) ::
+          {:ok, [module()]} | {:error, atom() | {atom(), term()}}
+  def actions_for(instance_module, target, selection \\ :all) when is_atom(instance_module) do
+    with {:ok, actions} <- select(selection),
+         {:ok, resolved} <- Resolver.resolve(%{target: target}, %{instance_module: instance_module}) do
+      {:ok, Executor.supported_actions(actions, resolved.adapter_module)}
+    else
+      {:error, code, details} -> {:error, {code, details}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc "Builds trusted Jido Action context with an explicit scope and policy."
+  @spec context(module(), map() | struct(), keyword() | map()) :: map()
+  def context(instance_module, active_context, opts \\ %{}) when is_atom(instance_module) and is_map(active_context) do
+    opts = normalize_opts(opts)
+    supplied_scope = get(opts, :scope) || get(active_context, :scope)
+    actor_id = trusted_actor_id(opts, active_context)
+
+    scope =
+      cond do
+        match?(%Scope{}, supplied_scope) -> supplied_scope
+        is_map(supplied_scope) -> Scope.from_map(supplied_scope)
+        true -> Scope.inherit(active_context, actor_id: actor_id)
+      end
+
+    scope = if scope, do: Scope.bind_actor(scope, actor_id)
+    actor_id = if scope, do: scope.actor_id, else: stringify(actor_id)
+
+    policy =
+      case get(opts, :policy) || get(active_context, :policy) do
+        %Policy{} = value -> value
+        value when is_map(value) -> Policy.from_map(value)
+        _ -> Policy.default()
+      end
+
+    %{
+      chat_action: %{
+        instance_module: instance_module,
+        active_context: active_context,
+        scope: scope,
+        policy: policy,
+        actor_id: actor_id,
+        target: get(opts, :target)
+      }
+    }
+  end
+
+  defp select(selection) when selection in [:reader, :messenger, :moderator, :all],
+    do: {:ok, preset(selection)}
+
+  defp select(actions) when is_list(actions) do
+    if Enum.all?(actions, &(&1 in @all)), do: {:ok, actions}, else: {:error, :unknown_action}
+  end
+
+  defp select(_selection), do: {:error, :unknown_preset}
+
+  defp normalize_opts(opts) when is_list(opts), do: Map.new(opts)
+  defp normalize_opts(opts) when is_map(opts), do: opts
+
+  defp trusted_actor_id(opts, active_context) do
+    get(opts, :actor_id) ||
+      get(active_context, :actor_id) ||
+      get(active_context, :participant_id) ||
+      get(active_context, :external_user_id)
+  end
+
+  defp get(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/jido_messaging/chat_actions/action.ex
+++ b/lib/jido_messaging/chat_actions/action.ex
@@ -1,0 +1,34 @@
+defmodule Jido.Messaging.ChatActions.Action do
+  @moduledoc false
+
+  defmacro __using__(opts) do
+    operation = Keyword.fetch!(opts, :operation)
+    name = Keyword.fetch!(opts, :name)
+    description = Keyword.fetch!(opts, :description)
+    schema = Keyword.fetch!(opts, :schema)
+
+    quote do
+      use Jido.Action,
+        name: unquote(name),
+        description: unquote(description),
+        schema: unquote(schema),
+        output_schema:
+          Zoi.object(%{
+            status: Zoi.atom(),
+            action: Zoi.atom(),
+            code: Zoi.atom() |> Zoi.optional(),
+            data: Zoi.any() |> Zoi.optional(),
+            details: Zoi.map() |> Zoi.optional(),
+            audit: Zoi.map()
+          })
+
+      @doc false
+      def chat_action_operation, do: unquote(operation)
+
+      @impl true
+      def run(params, context) do
+        Jido.Messaging.ChatActions.Executor.execute(unquote(operation), params, context)
+      end
+    end
+  end
+end

--- a/lib/jido_messaging/chat_actions/executor.ex
+++ b/lib/jido_messaging/chat_actions/executor.ex
@@ -1,0 +1,495 @@
+defmodule Jido.Messaging.ChatActions.Executor do
+  @moduledoc false
+
+  alias Jido.Chat.{Adapter, Message, PostPayload}
+
+  alias Jido.Messaging.{Directory, IngressSubscriptions}
+
+  alias Jido.Messaging.ChatActions.{Policy, Resolver, Result, Scope}
+
+  @visible_writes [
+    :post_message,
+    :post_channel_message,
+    :send_direct_message,
+    :edit_message,
+    :delete_message,
+    :add_reaction,
+    :remove_reaction,
+    :ensure_subscription,
+    :delete_subscription
+  ]
+
+  @workspace_operations [
+    :lookup_user,
+    :send_direct_message,
+    :ensure_subscription,
+    :list_subscriptions,
+    :delete_subscription
+  ]
+
+  @channel_only_operations [
+    :fetch_channel_messages,
+    :list_threads,
+    :fetch_channel_metadata,
+    :post_channel_message
+  ]
+
+  @message_operations [
+    :fetch_message,
+    :edit_message,
+    :delete_message,
+    :add_reaction,
+    :remove_reaction
+  ]
+
+  @spec execute(atom(), map(), map()) :: {:ok, map()}
+  def execute(action, params, context) when is_atom(action) and is_map(params) and is_map(context) do
+    with {:ok, target} <- Resolver.resolve(params, context),
+         :ok <- ensure_supported(action, target),
+         {:ok, scope} <- resolve_scope(context),
+         :ok <- ensure_workspace_scope(action, scope),
+         :ok <- authorize_scope(scope, target),
+         :ok <- ensure_execution_scope(action, scope, target),
+         audit = audit(action, target, scope),
+         :ok <- authorize_write(action, audit, context),
+         {:ok, target} <- verify_message_scope(action, params, target, scope),
+         {:ok, data} <- invoke(action, params, target) do
+      {:ok, Result.ok(action, target, data, audit)}
+    else
+      {:policy, :deny, audit} ->
+        {:ok, Result.denied(action, :policy_denied, audit)}
+
+      {:policy, :needs_approval, audit} ->
+        {:ok, Result.approval_required(action, audit)}
+
+      {:scope, code, audit} ->
+        {:ok, Result.denied(action, code, audit)}
+
+      {:error, code, details} ->
+        {:ok, Result.error(action, code, details)}
+
+      {:provider_error, reason, target, audit} ->
+        {:ok,
+         Result.error(action, provider_error_code(reason), %{reason: safe_reason(reason)}, audit_for(target, audit))}
+    end
+  end
+
+  @doc false
+  @spec supported_actions([module()], module()) :: [module()]
+  def supported_actions(actions, adapter_module) when is_list(actions) and is_atom(adapter_module) do
+    matrix = Adapter.capabilities(adapter_module)
+
+    Enum.filter(actions, fn action ->
+      supported_with_matrix?(action.chat_action_operation(), adapter_module, matrix)
+    end)
+  end
+
+  @doc false
+  @spec supported?(atom(), module()) :: boolean()
+  def supported?(action, adapter_module) do
+    matrix = Adapter.capabilities(adapter_module)
+
+    supported_with_matrix?(action, adapter_module, matrix)
+  end
+
+  defp supported_with_matrix?(:post_message, _adapter_module, matrix) do
+    supported_capability?(matrix, :post_message) or supported_capability?(matrix, :send_message)
+  end
+
+  defp supported_with_matrix?(action, adapter_module, matrix) do
+    case capability(action) do
+      {:adapter, capability} -> supported_capability?(matrix, capability)
+      {:callback, callback, arity} -> function_exported?(adapter_module, callback, arity)
+      :directory -> true
+      :none -> false
+    end
+  end
+
+  defp supported_capability?(matrix, capability) do
+    Map.get(matrix, capability, :unsupported) in [:native, :fallback]
+  end
+
+  defp ensure_supported(action, target) do
+    if supported?(action, target.adapter_module) do
+      :ok
+    else
+      {:error, :unsupported_operation, %{adapter: target.adapter, action: action}}
+    end
+  end
+
+  defp resolve_scope(context) do
+    runtime_context = Resolver.runtime_context(context)
+    raw_scope = get(runtime_context, :scope)
+
+    scope =
+      cond do
+        match?(%Scope{}, raw_scope) -> raw_scope
+        is_map(raw_scope) -> Scope.from_map(raw_scope)
+        true -> Scope.inherit(get(runtime_context, :active_context) || get(runtime_context, :msg_context) || %{})
+      end
+
+    case scope do
+      %Scope{} -> {:ok, Scope.bind_actor(scope, get(runtime_context, :actor_id))}
+      nil -> {:error, :missing_scope, %{field: :scope}}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_scope, %{field: :scope}}
+  end
+
+  defp ensure_workspace_scope(action, %Scope{kind: :workspace, explicit: true})
+       when action in @workspace_operations,
+       do: :ok
+
+  defp ensure_workspace_scope(action, scope) when action in @workspace_operations do
+    {:scope, :workspace_scope_required, scope_audit(scope)}
+  end
+
+  defp ensure_workspace_scope(_action, _scope), do: :ok
+
+  defp authorize_scope(scope, target) do
+    case Scope.authorize(scope, target) do
+      :ok -> :ok
+      {:error, code} -> {:scope, code, Map.merge(scope_audit(scope), target_audit(target))}
+    end
+  end
+
+  defp ensure_execution_scope(action, %Scope{kind: :strict_thread} = scope, target)
+       when action in @channel_only_operations do
+    {:scope, :out_of_scope, Map.merge(scope_audit(scope), target_audit(target))}
+  end
+
+  defp ensure_execution_scope(_action, _scope, _target), do: :ok
+
+  defp authorize_write(action, audit, context) when action in @visible_writes do
+    runtime_context = Resolver.runtime_context(context)
+
+    policy =
+      case get(runtime_context, :policy) do
+        %Policy{} = value -> value
+        value when is_map(value) -> Policy.from_map(value)
+        _ -> Policy.default()
+      end
+
+    case Policy.evaluate(policy, audit) do
+      :allow -> :ok
+      :deny -> {:policy, :deny, Map.put(audit, :policy_metadata, policy.metadata)}
+      :needs_approval -> {:policy, :needs_approval, Map.put(audit, :policy_metadata, policy.metadata)}
+    end
+  rescue
+    ArgumentError -> {:error, :invalid_policy, %{field: :policy}}
+  end
+
+  defp authorize_write(_action, _audit, _context), do: :ok
+
+  defp invoke(:fetch_message, _params, %{verified_message: %Message{} = message}), do: {:ok, message}
+
+  defp invoke(:fetch_message, params, target) do
+    call(target, fn ->
+      Adapter.fetch_message(
+        target.adapter_module,
+        target.channel_id,
+        fetch!(params, :message_id),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp invoke(:fetch_channel_messages, params, target) do
+    call(target, fn ->
+      Adapter.fetch_channel_messages(target.adapter_module, target.channel_id, page_opts(params, target))
+    end)
+  end
+
+  defp invoke(:fetch_thread, _params, target) do
+    call(target, fn -> Adapter.fetch_thread(target.adapter_module, target.channel_id, target.adapter_opts) end)
+  end
+
+  defp invoke(:fetch_thread_messages, params, target) do
+    call(target, fn -> Adapter.fetch_messages(target.adapter_module, target.channel_id, page_opts(params, target)) end)
+  end
+
+  defp invoke(:list_threads, params, target) do
+    call(target, fn -> Adapter.list_threads(target.adapter_module, target.channel_id, page_opts(params, target)) end)
+  end
+
+  defp invoke(:fetch_channel_metadata, _params, target) do
+    call(target, fn -> Adapter.fetch_metadata(target.adapter_module, target.channel_id, target.adapter_opts) end)
+  end
+
+  defp invoke(:lookup_participant, params, target) do
+    query = scoped_directory_query(fetch!(params, :query), target)
+
+    call(target, fn -> Directory.lookup(target.instance_module, :participant, query, target.adapter_opts) end)
+  end
+
+  defp invoke(:lookup_user, params, target) do
+    query = fetch!(params, :query)
+
+    if function_exported?(target.adapter_module, :lookup_user, 2) do
+      call(target, fn -> target.adapter_module.lookup_user(query, target.adapter_opts) end)
+    else
+      call(target, fn ->
+        Directory.lookup(
+          target.instance_module,
+          :participant,
+          scoped_directory_query(query, target),
+          target.adapter_opts
+        )
+      end)
+    end
+  end
+
+  defp invoke(:post_message, params, target) do
+    opts = Keyword.put(target.adapter_opts, :scope, if(target.thread_id, do: :thread, else: :channel))
+
+    call(target, fn ->
+      Adapter.post_message(target.adapter_module, target.channel_id, PostPayload.text(fetch!(params, :text)), opts)
+    end)
+  end
+
+  defp invoke(:post_channel_message, params, target) do
+    call(target, fn ->
+      Adapter.post_channel_message(target.adapter_module, target.channel_id, fetch!(params, :text), target.adapter_opts)
+    end)
+  end
+
+  defp invoke(:send_direct_message, params, target) do
+    with {:ok, room_id} <- target.adapter_module.open_dm(fetch!(params, :user_id), target.adapter_opts) do
+      call(%{target | channel_id: to_string(room_id), thread_id: nil}, fn ->
+        Adapter.post_message(
+          target.adapter_module,
+          room_id,
+          PostPayload.text(fetch!(params, :text)),
+          Keyword.put(target.adapter_opts, :scope, :channel)
+        )
+      end)
+    else
+      {:error, reason} -> provider_error(reason, target)
+      other -> provider_error({:invalid_open_dm_result, other}, target)
+    end
+  end
+
+  defp invoke(:edit_message, params, target) do
+    call(target, fn ->
+      Adapter.edit_message(
+        target.adapter_module,
+        target.channel_id,
+        fetch!(params, :message_id),
+        fetch!(params, :text),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp invoke(:delete_message, params, target) do
+    call(target, fn ->
+      Adapter.delete_message(
+        target.adapter_module,
+        target.channel_id,
+        fetch!(params, :message_id),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp invoke(:add_reaction, params, target) do
+    call(target, fn ->
+      Adapter.add_reaction(
+        target.adapter_module,
+        target.channel_id,
+        fetch!(params, :message_id),
+        fetch!(params, :emoji),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp invoke(:remove_reaction, params, target) do
+    call(target, fn ->
+      Adapter.remove_reaction(
+        target.adapter_module,
+        target.channel_id,
+        fetch!(params, :message_id),
+        fetch!(params, :emoji),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp invoke(:start_typing, _params, target) do
+    call(target, fn -> Adapter.start_typing(target.adapter_module, target.channel_id, target.adapter_opts) end)
+  end
+
+  defp invoke(:ensure_subscription, _params, target) do
+    call(target, fn ->
+      IngressSubscriptions.ensure(target.instance_module, target.bridge_id, target.adapter_opts)
+    end)
+  end
+
+  defp invoke(:list_subscriptions, _params, target) do
+    call(target, fn -> IngressSubscriptions.list(target.instance_module, target.bridge_id, target.adapter_opts) end)
+  end
+
+  defp invoke(:delete_subscription, params, target) do
+    call(target, fn ->
+      IngressSubscriptions.delete(
+        target.instance_module,
+        target.bridge_id,
+        fetch!(params, :subscription_id),
+        target.adapter_opts
+      )
+    end)
+  end
+
+  defp call(target, function) do
+    case function.() do
+      {:ok, data} -> {:ok, data}
+      :ok -> {:ok, %{completed: true}}
+      {:error, reason} -> provider_error(reason, target)
+      other -> provider_error({:invalid_adapter_result, other}, target)
+    end
+  rescue
+    exception -> provider_error({:exception, Exception.message(exception)}, target)
+  catch
+    kind, reason -> provider_error({kind, reason}, target)
+  end
+
+  defp verify_message_scope(action, params, target, %Scope{kind: kind} = scope)
+       when action in @message_operations and kind in [:thread, :strict_thread] and
+              is_binary(target.thread_id) do
+    message_id = fetch!(params, :message_id)
+    verification_opts = Keyword.drop(target.adapter_opts, [:thread_id, :external_thread_id])
+
+    case call(target, fn ->
+           Adapter.fetch_message(
+             target.adapter_module,
+             target.channel_id,
+             message_id,
+             verification_opts
+           )
+         end) do
+      {:ok, %Message{} = message} ->
+        if message_in_target?(message, target) do
+          {:ok, Map.put(target, :verified_message, message)}
+        else
+          {:scope, :out_of_scope, Map.merge(scope_audit(scope), target_audit(target))}
+        end
+
+      {:provider_error, _reason, _target, _audit} = error ->
+        error
+    end
+  end
+
+  defp verify_message_scope(_action, _params, target, _scope), do: {:ok, target}
+
+  defp message_in_target?(%Message{} = message, target) do
+    message_channel_id = message.external_room_id || message.channel_id
+    canonical_thread_id = "#{target.adapter}:#{target.channel_id}:#{target.thread_id}"
+
+    to_string(message_channel_id) == target.channel_id and
+      message.thread_id in [target.thread_id, canonical_thread_id]
+  end
+
+  defp provider_error(reason, target), do: {:provider_error, reason, target, %{}}
+
+  defp page_opts(params, target) do
+    target.adapter_opts
+    |> maybe_put(:cursor, get(params, :cursor))
+    |> maybe_put(:limit, get(params, :limit))
+    |> maybe_put(:direction, normalize_direction(get(params, :direction)))
+  end
+
+  defp scoped_directory_query(query, target) do
+    query
+    |> normalize_map()
+    |> Map.put(:channel, target.adapter)
+  end
+
+  defp audit(action, target, scope) do
+    target_audit(target)
+    |> Map.put(:action, action)
+    |> Map.put(:actor_id, scope.actor_id)
+    |> Map.put(:scope_kind, scope.kind)
+    |> Map.put(:scope_metadata, scope.metadata)
+  end
+
+  defp target_audit(target) do
+    %{
+      adapter: target.adapter,
+      bridge_id: target.bridge_id,
+      channel_id: target.channel_id,
+      thread_id: target.thread_id,
+      workspace_id: target.workspace_id
+    }
+  end
+
+  defp audit_for(target, extra), do: Map.merge(target_audit(target), extra)
+
+  defp scope_audit(scope) do
+    %{
+      actor_id: scope.actor_id,
+      scope_kind: scope.kind,
+      bridge_id: scope.bridge_id,
+      adapter: scope.adapter,
+      channel_id: scope.channel_id,
+      thread_id: scope.thread_id,
+      workspace_id: scope.workspace_id,
+      scope_metadata: scope.metadata
+    }
+  end
+
+  defp capability(:fetch_message), do: {:adapter, :fetch_message}
+  defp capability(:fetch_channel_messages), do: {:adapter, :fetch_channel_messages}
+  defp capability(:fetch_thread), do: {:adapter, :fetch_thread}
+  defp capability(:fetch_thread_messages), do: {:adapter, :fetch_messages}
+  defp capability(:list_threads), do: {:adapter, :list_threads}
+  defp capability(:fetch_channel_metadata), do: {:adapter, :fetch_metadata}
+  defp capability(:lookup_participant), do: :directory
+  defp capability(:lookup_user), do: :directory
+  defp capability(:post_channel_message), do: {:adapter, :post_channel_message}
+  defp capability(:send_direct_message), do: {:adapter, :open_dm}
+  defp capability(:edit_message), do: {:adapter, :edit_message}
+  defp capability(:delete_message), do: {:adapter, :delete_message}
+  defp capability(:add_reaction), do: {:adapter, :add_reaction}
+  defp capability(:remove_reaction), do: {:adapter, :remove_reaction}
+  defp capability(:start_typing), do: {:adapter, :start_typing}
+  defp capability(:ensure_subscription), do: {:callback, :ensure_ingress_subscription, 2}
+  defp capability(:list_subscriptions), do: {:callback, :list_ingress_subscriptions, 2}
+  defp capability(:delete_subscription), do: {:callback, :delete_ingress_subscription, 3}
+  defp capability(_action), do: :none
+
+  defp provider_error_code(:unsupported), do: :unsupported_operation
+  defp provider_error_code({:unsupported, _reason}), do: :unsupported_operation
+  defp provider_error_code(:not_found), do: :not_found
+  defp provider_error_code({:ambiguous, _matches}), do: :ambiguous
+  defp provider_error_code(_reason), do: :provider_error
+
+  defp safe_reason(reason) when is_atom(reason), do: reason
+  defp safe_reason({type, _detail}) when is_atom(type), do: %{type: type}
+  defp safe_reason(%{type: type}) when is_atom(type), do: %{type: type}
+  defp safe_reason(_reason), do: %{type: :provider_error}
+
+  defp fetch!(map, key), do: Map.get(map, key) || Map.fetch!(map, Atom.to_string(key))
+  defp get(map, key) when is_map(map), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp normalize_map(map) do
+    Map.new(map, fn
+      {key, value} when is_binary(key) -> {safe_existing_atom(key), value}
+      pair -> pair
+    end)
+  end
+
+  defp safe_existing_atom(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> value
+  end
+
+  defp normalize_direction(value) when value in [:forward, :backward], do: value
+  defp normalize_direction("forward"), do: :forward
+  defp normalize_direction("backward"), do: :backward
+  defp normalize_direction(_value), do: nil
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/lib/jido_messaging/chat_actions/messenger.ex
+++ b/lib/jido_messaging/chat_actions/messenger.ex
@@ -1,0 +1,40 @@
+defmodule Jido.Messaging.ChatActions.Messenger.PostMessage do
+  @moduledoc "Posts a message in the authorized channel or thread."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :post_message,
+    name: "chat_post_message",
+    description: "Post a message in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.MessengerSchema.text()
+end
+
+defmodule Jido.Messaging.ChatActions.Messenger.PostChannelMessage do
+  @moduledoc "Posts a channel-level message."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :post_channel_message,
+    name: "chat_post_channel_message",
+    description: "Post a message at channel level.",
+    schema: Jido.Messaging.ChatActions.MessengerSchema.text()
+end
+
+defmodule Jido.Messaging.ChatActions.Messenger.SendDirectMessage do
+  @moduledoc "Opens a direct-message room and posts a message."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :send_direct_message,
+    name: "chat_send_direct_message",
+    description: "Send a direct message under explicit workspace authority.",
+    schema:
+      Zoi.object(%{
+        target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+        user_id: Zoi.string(description: "Provider user identifier"),
+        text: Zoi.string(description: "Message text")
+      })
+end
+
+defmodule Jido.Messaging.ChatActions.Messenger.StartTyping do
+  @moduledoc "Starts a typing indicator for the authorized target."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :start_typing,
+    name: "chat_start_typing",
+    description: "Start a typing indicator in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.target()
+end

--- a/lib/jido_messaging/chat_actions/moderator.ex
+++ b/lib/jido_messaging/chat_actions/moderator.ex
@@ -1,0 +1,66 @@
+defmodule Jido.Messaging.ChatActions.Moderator.EditMessage do
+  @moduledoc "Edits a message after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :edit_message,
+    name: "chat_edit_message",
+    description: "Edit a message in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.ModeratorSchema.message_text()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.DeleteMessage do
+  @moduledoc "Deletes a message after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :delete_message,
+    name: "chat_delete_message",
+    description: "Delete a message in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.ModeratorSchema.message()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.AddReaction do
+  @moduledoc "Adds a reaction after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :add_reaction,
+    name: "chat_add_reaction",
+    description: "Add a reaction to a message in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.ModeratorSchema.reaction()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.RemoveReaction do
+  @moduledoc "Removes a reaction after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :remove_reaction,
+    name: "chat_remove_reaction",
+    description: "Remove a reaction from a message in the authorized chat target.",
+    schema: Jido.Messaging.ChatActions.ModeratorSchema.reaction()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.EnsureSubscription do
+  @moduledoc "Ensures a provider subscription after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :ensure_subscription,
+    name: "chat_ensure_subscription",
+    description: "Ensure a provider subscription under explicit workspace authority.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.target()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.ListSubscriptions do
+  @moduledoc "Lists provider subscriptions under explicit workspace authority."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :list_subscriptions,
+    name: "chat_list_subscriptions",
+    description: "List provider subscriptions under explicit workspace authority.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.target()
+end
+
+defmodule Jido.Messaging.ChatActions.Moderator.DeleteSubscription do
+  @moduledoc "Deletes a provider subscription after policy approval."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :delete_subscription,
+    name: "chat_delete_subscription",
+    description: "Delete a provider subscription under explicit workspace authority.",
+    schema:
+      Zoi.object(%{
+        target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+        subscription_id: Zoi.string(description: "Provider subscription identifier")
+      })
+end

--- a/lib/jido_messaging/chat_actions/policy.ex
+++ b/lib/jido_messaging/chat_actions/policy.ex
@@ -1,0 +1,140 @@
+defmodule Jido.Messaging.ChatActions.Policy do
+  @moduledoc """
+  Serializable approval policy for visible chat writes.
+
+  Rules are checked in list order. An empty selector is a wildcard. The default
+  result is `:needs_approval`, which makes visible writes safe by default.
+  """
+
+  @results [:allow, :deny, :needs_approval]
+  @selector_keys [:actions, :adapters, :bridge_ids, :channels, :threads, :actors]
+
+  defstruct default: :needs_approval, rules: [], metadata: %{}
+
+  @type result :: :allow | :deny | :needs_approval
+  @type rule :: %{
+          required(:result) => result(),
+          required(:actions) => [atom()],
+          required(:adapters) => [atom()],
+          required(:bridge_ids) => [String.t()],
+          required(:channels) => [String.t()],
+          required(:threads) => [String.t()],
+          required(:actors) => [String.t()]
+        }
+  @type t :: %__MODULE__{default: result(), rules: [rule()], metadata: map()}
+
+  @doc "Returns the safe default policy."
+  @spec default() :: t()
+  def default, do: %__MODULE__{}
+
+  @doc "Builds a policy from a struct or plain map."
+  @spec new(map() | t()) :: t()
+  def new(%__MODULE__{} = policy), do: policy
+
+  def new(attrs) when is_map(attrs) do
+    %__MODULE__{
+      default: attrs |> get(:default) |> Kernel.||(:needs_approval) |> normalize_result(),
+      rules: attrs |> get(:rules) |> Kernel.||([]) |> Enum.map(&normalize_rule/1),
+      metadata: get(attrs, :metadata) || %{}
+    }
+  end
+
+  @doc "Creates a safe policy with one narrow allow rule."
+  @spec allow([atom()], keyword()) :: t()
+  def allow(actions, opts \\ []) when is_list(actions) do
+    rule = %{
+      result: :allow,
+      actions: actions,
+      adapters: atom_list_opt(opts, :adapter),
+      bridge_ids: list_opt(opts, :bridge_id),
+      channels: list_opt(opts, :channel),
+      threads: list_opt(opts, :thread),
+      actors: list_opt(opts, :actor)
+    }
+
+    new(%{rules: [rule]})
+  end
+
+  @doc "Converts a policy to a JSON-safe plain map."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = policy) do
+    %{
+      "default" => Atom.to_string(policy.default),
+      "rules" => Enum.map(policy.rules, &serialize_rule/1),
+      "metadata" => policy.metadata
+    }
+  end
+
+  @doc "Builds a policy from serialized data."
+  @spec from_map(map() | t()) :: t()
+  def from_map(value), do: new(value)
+
+  @doc false
+  @spec evaluate(t(), map()) :: result()
+  def evaluate(%__MODULE__{} = policy, audit) when is_map(audit) do
+    case Enum.find(policy.rules, &matches?(&1, audit)) do
+      nil -> policy.default
+      rule -> rule.result
+    end
+  end
+
+  defp matches?(rule, audit) do
+    selector_matches?(rule.actions, audit.action) and
+      selector_matches?(rule.adapters, audit.adapter) and
+      selector_matches?(rule.bridge_ids, audit.bridge_id) and
+      selector_matches?(rule.channels, audit.channel_id) and
+      selector_matches?(rule.threads, audit.thread_id) and
+      selector_matches?(rule.actors, audit.actor_id)
+  end
+
+  defp selector_matches?([], _value), do: true
+  defp selector_matches?(values, value), do: value in values
+
+  defp normalize_rule(rule) when is_map(rule) do
+    %{
+      result: rule |> get(:result) |> Kernel.||(:needs_approval) |> normalize_result(),
+      actions: normalize_atoms(get(rule, :actions)),
+      adapters: normalize_atoms(get(rule, :adapters)),
+      bridge_ids: normalize_strings(get(rule, :bridge_ids)),
+      channels: normalize_strings(get(rule, :channels)),
+      threads: normalize_strings(get(rule, :threads)),
+      actors: normalize_strings(get(rule, :actors))
+    }
+  end
+
+  defp serialize_rule(rule) do
+    Map.new([:result | @selector_keys], fn
+      :result -> {"result", Atom.to_string(rule.result)}
+      key -> {Atom.to_string(key), Enum.map(Map.fetch!(rule, key), &stringify/1)}
+    end)
+  end
+
+  defp normalize_result(result) when result in @results, do: result
+
+  defp normalize_result(result) when is_binary(result) do
+    Enum.find(@results, fn item -> Atom.to_string(item) == result end) ||
+      raise ArgumentError, "invalid policy result"
+  end
+
+  defp normalize_result(_result), do: raise(ArgumentError, "invalid policy result")
+
+  defp normalize_atoms(nil), do: []
+
+  defp normalize_atoms(values) do
+    values
+    |> List.wrap()
+    |> Enum.map(fn
+      value when is_atom(value) -> value
+      value when is_binary(value) -> String.to_existing_atom(value)
+    end)
+  end
+
+  defp normalize_strings(nil), do: []
+  defp normalize_strings(values), do: values |> List.wrap() |> Enum.map(&stringify/1)
+  defp atom_list_opt(opts, key), do: opts |> Keyword.get(key) |> normalize_atoms()
+  defp list_opt(opts, key), do: opts |> Keyword.get(key) |> normalize_strings()
+
+  defp get(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/jido_messaging/chat_actions/reader.ex
+++ b/lib/jido_messaging/chat_actions/reader.ex
@@ -1,0 +1,75 @@
+defmodule Jido.Messaging.ChatActions.Reader.FetchMessage do
+  @moduledoc "Fetches one normalized message in the authorized conversation."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :fetch_message,
+    name: "chat_fetch_message",
+    description: "Fetch one message from the authorized chat target.",
+    schema:
+      Zoi.object(%{
+        target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+        message_id: Zoi.string(description: "Provider message identifier")
+      })
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.FetchChannelMessages do
+  @moduledoc "Fetches a normalized page of channel messages."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :fetch_channel_messages,
+    name: "chat_fetch_channel_messages",
+    description: "Fetch messages from the authorized channel.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.page()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.FetchThread do
+  @moduledoc "Fetches normalized thread metadata."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :fetch_thread,
+    name: "chat_fetch_thread",
+    description: "Fetch metadata for the authorized thread.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.target()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.FetchThreadMessages do
+  @moduledoc "Fetches a normalized page of thread messages."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :fetch_thread_messages,
+    name: "chat_fetch_thread_messages",
+    description: "Fetch messages from the authorized thread.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.page()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.ListThreads do
+  @moduledoc "Lists normalized thread summaries in an authorized channel."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :list_threads,
+    name: "chat_list_threads",
+    description: "List threads in the authorized channel.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.page()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.LookupParticipant do
+  @moduledoc "Looks up a participant through the runtime directory."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :lookup_participant,
+    name: "chat_lookup_participant",
+    description: "Look up one participant in the authorized adapter directory.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.lookup()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.LookupUser do
+  @moduledoc "Looks up a provider user through an available directory seam."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :lookup_user,
+    name: "chat_lookup_user",
+    description: "Look up one user in the authorized adapter directory.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.lookup()
+end
+
+defmodule Jido.Messaging.ChatActions.Reader.FetchChannelMetadata do
+  @moduledoc "Fetches normalized channel metadata."
+  use Jido.Messaging.ChatActions.Action,
+    operation: :fetch_channel_metadata,
+    name: "chat_fetch_channel_metadata",
+    description: "Fetch metadata for the authorized channel.",
+    schema: Jido.Messaging.ChatActions.ReaderSchema.target()
+end

--- a/lib/jido_messaging/chat_actions/resolver.ex
+++ b/lib/jido_messaging/chat_actions/resolver.ex
@@ -1,0 +1,134 @@
+defmodule Jido.Messaging.ChatActions.Resolver do
+  @moduledoc false
+
+  alias Jido.Chat.MessagingTarget
+  alias Jido.Messaging.{AdapterBridge, BridgeConfig, ConfigStore}
+
+  @type resolved :: %{
+          required(:instance_module) => module(),
+          required(:bridge_id) => String.t(),
+          required(:adapter) => atom(),
+          required(:adapter_module) => module(),
+          required(:channel_id) => String.t(),
+          optional(:thread_id) => String.t() | nil,
+          optional(:workspace_id) => String.t() | nil,
+          required(:adapter_opts) => keyword()
+        }
+
+  @doc false
+  @spec resolve(map(), map()) :: {:ok, resolved()} | {:error, atom(), map()}
+  def resolve(params, context) when is_map(params) and is_map(context) do
+    runtime_context = runtime_context(context)
+
+    with {:ok, instance_module} <- fetch_instance(runtime_context),
+         {:ok, target} <- fetch_target(params, runtime_context),
+         {:ok, bridge_id} <- fetch_bridge_id(target),
+         {:ok, %BridgeConfig{} = config} <- fetch_bridge(instance_module, bridge_id),
+         {:ok, channel_id} <- fetch_channel_id(target),
+         :ok <- validate_adapter_claim(target, config.adapter_module) do
+      adapter = AdapterBridge.channel_type(config.adapter_module)
+      thread_id = stringify(get(target, :thread_id))
+      workspace_id = config.opts |> get(:workspace_id) |> stringify()
+
+      {:ok,
+       %{
+         instance_module: instance_module,
+         bridge_id: config.id,
+         adapter: adapter,
+         adapter_module: config.adapter_module,
+         channel_id: channel_id,
+         thread_id: thread_id,
+         workspace_id: workspace_id,
+         adapter_opts: adapter_opts(instance_module, config, thread_id)
+       }}
+    end
+  end
+
+  @doc false
+  @spec runtime_context(map()) :: map()
+  def runtime_context(context) do
+    get(context, :chat_action) || context
+  end
+
+  defp fetch_instance(context) do
+    case get(context, :instance_module) do
+      module when is_atom(module) -> {:ok, module}
+      _ -> {:error, :missing_runtime_context, %{field: :instance_module}}
+    end
+  end
+
+  defp fetch_target(params, context) do
+    target = get(params, :target) || get(context, :target) || inherited_target(context)
+
+    case target do
+      %MessagingTarget{} = value -> {:ok, Map.from_struct(value)}
+      value when is_map(value) -> {:ok, value}
+      _ -> {:error, :missing_target, %{field: :target}}
+    end
+  end
+
+  defp inherited_target(context) do
+    active = get(context, :active_context) || get(context, :msg_context)
+
+    if is_map(active) and get(active, :external_room_id) do
+      active
+      |> MessagingTarget.from_context()
+      |> Map.from_struct()
+    end
+  end
+
+  defp fetch_bridge_id(target) do
+    case get(target, :instance_id) || get(target, :bridge_id) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      value when not is_nil(value) -> {:ok, to_string(value)}
+      _ -> {:error, :missing_bridge_id, %{field: :target}}
+    end
+  end
+
+  defp fetch_bridge(instance_module, bridge_id) do
+    case ConfigStore.get_bridge_config(instance_module, bridge_id) do
+      {:ok, %BridgeConfig{enabled: true} = config} -> {:ok, config}
+      {:ok, %BridgeConfig{enabled: false}} -> {:error, :bridge_disabled, %{bridge_id: bridge_id}}
+      {:error, :not_found} -> {:error, :bridge_not_found, %{bridge_id: bridge_id}}
+    end
+  end
+
+  defp fetch_channel_id(target) do
+    case get(target, :external_id) || get(target, :external_room_id) || get(target, :channel_id) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      value when not is_nil(value) -> {:ok, to_string(value)}
+      _ -> {:error, :missing_channel_id, %{field: :target}}
+    end
+  end
+
+  defp validate_adapter_claim(target, adapter_module) do
+    expected = AdapterBridge.channel_type(adapter_module)
+    expected_string = Atom.to_string(expected)
+
+    case get(target, :channel_type) do
+      nil -> :ok
+      ^expected -> :ok
+      ^expected_string -> :ok
+      _ -> {:error, :target_mismatch, %{field: :channel_type, expected: expected}}
+    end
+  end
+
+  defp adapter_opts(instance_module, %BridgeConfig{} = config, thread_id) do
+    []
+    |> Keyword.put(:instance_module, instance_module)
+    |> Keyword.put(:bridge_id, config.id)
+    |> Keyword.put(:bridge_config, config)
+    |> Keyword.put(:credentials, config.credentials)
+    |> Keyword.put(:settings, config.opts)
+    |> maybe_put(:thread_id, thread_id)
+    |> maybe_put(:external_thread_id, thread_id)
+  end
+
+  defp get(nil, _key), do: nil
+  defp get(map, key) when is_map(map), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+end

--- a/lib/jido_messaging/chat_actions/result.ex
+++ b/lib/jido_messaging/chat_actions/result.ex
@@ -1,0 +1,56 @@
+defmodule Jido.Messaging.ChatActions.Result do
+  @moduledoc "Stable serializable result helpers for scoped chat actions."
+
+  @doc false
+  @spec ok(atom(), map(), term(), map()) :: map()
+  def ok(action, target, data, audit) do
+    base(:ok, action, target, audit)
+    |> Map.put(:data, data)
+  end
+
+  @doc false
+  @spec error(atom(), atom(), map(), map()) :: map()
+  def error(action, code, details \\ %{}, audit \\ %{}) do
+    %{
+      status: :error,
+      code: code,
+      action: action,
+      details: details,
+      audit: audit
+    }
+  end
+
+  @doc false
+  @spec denied(atom(), atom(), map()) :: map()
+  def denied(action, code, audit) do
+    %{
+      status: :denied,
+      code: code,
+      action: action,
+      audit: audit
+    }
+  end
+
+  @doc false
+  @spec approval_required(atom(), map()) :: map()
+  def approval_required(action, audit) do
+    %{
+      status: :approval_required,
+      code: :approval_required,
+      action: action,
+      audit: audit
+    }
+  end
+
+  defp base(status, action, target, audit) do
+    %{
+      status: status,
+      action: action,
+      adapter: target.adapter,
+      bridge_id: target.bridge_id,
+      channel_id: target.channel_id,
+      thread_id: target.thread_id,
+      audit: audit
+    }
+  end
+end

--- a/lib/jido_messaging/chat_actions/schemas.ex
+++ b/lib/jido_messaging/chat_actions/schemas.ex
@@ -1,0 +1,93 @@
+defmodule Jido.Messaging.ChatActions.TargetSchema do
+  @moduledoc false
+
+  @doc false
+  @spec schema() :: Zoi.schema()
+  def schema do
+    Zoi.object(%{
+      kind: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.optional(),
+      external_id: Zoi.string(description: "Provider channel or room identifier"),
+      thread_id: Zoi.string(description: "Provider thread identifier") |> Zoi.nullish(),
+      reply_to_mode: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.optional(),
+      reply_to_id: Zoi.string(description: "Provider reply identifier") |> Zoi.nullish(),
+      instance_id: Zoi.string(description: "Configured bridge identifier"),
+      channel_type: Zoi.union([Zoi.atom(), Zoi.string()]) |> Zoi.nullish()
+    })
+  end
+end
+
+defmodule Jido.Messaging.ChatActions.ReaderSchema do
+  @moduledoc false
+
+  @doc false
+  @spec target() :: Zoi.schema()
+  def target do
+    Zoi.object(%{target: Jido.Messaging.ChatActions.TargetSchema.schema()})
+  end
+
+  @doc false
+  @spec page() :: Zoi.schema()
+  def page do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      cursor: Zoi.string(description: "Page cursor") |> Zoi.optional(),
+      limit: Zoi.integer(description: "Maximum items") |> Zoi.min(1) |> Zoi.max(200) |> Zoi.optional(),
+      direction: Zoi.enum([:forward, :backward]) |> Zoi.optional()
+    })
+  end
+
+  @doc false
+  @spec lookup() :: Zoi.schema()
+  def lookup do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      query: Zoi.map(description: "Normalized directory query")
+    })
+  end
+end
+
+defmodule Jido.Messaging.ChatActions.MessengerSchema do
+  @moduledoc false
+
+  @doc false
+  @spec text() :: Zoi.schema()
+  def text do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      text: Zoi.string(description: "Message text")
+    })
+  end
+end
+
+defmodule Jido.Messaging.ChatActions.ModeratorSchema do
+  @moduledoc false
+
+  @doc false
+  @spec message() :: Zoi.schema()
+  def message do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      message_id: Zoi.string(description: "Provider message identifier")
+    })
+  end
+
+  @doc false
+  @spec message_text() :: Zoi.schema()
+  def message_text do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      message_id: Zoi.string(description: "Provider message identifier"),
+      text: Zoi.string(description: "Replacement message text")
+    })
+  end
+
+  @doc false
+  @spec reaction() :: Zoi.schema()
+  def reaction do
+    Zoi.object(%{
+      target: Jido.Messaging.ChatActions.TargetSchema.schema(),
+      message_id: Zoi.string(description: "Provider message identifier"),
+      emoji: Zoi.string(description: "Reaction emoji")
+    })
+  end
+end

--- a/lib/jido_messaging/chat_actions/scope.ex
+++ b/lib/jido_messaging/chat_actions/scope.ex
@@ -1,0 +1,211 @@
+defmodule Jido.Messaging.ChatActions.Scope do
+  @moduledoc """
+  Serializable authorization scope for chat actions.
+
+  A scope is runtime context. It is not an action parameter, so a model cannot
+  expand its own authority. Channel and thread identifiers are provider-facing
+  canonical identifiers after bridge resolution.
+  """
+
+  @kinds [:channel, :thread, :strict_thread, :workspace]
+
+  @enforce_keys [:kind]
+  defstruct kind: nil,
+            bridge_id: nil,
+            adapter: nil,
+            channel_id: nil,
+            thread_id: nil,
+            workspace_id: nil,
+            actor_id: nil,
+            explicit: false,
+            metadata: %{}
+
+  @type kind :: :channel | :thread | :strict_thread | :workspace
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          bridge_id: String.t() | nil,
+          adapter: atom() | nil,
+          channel_id: String.t() | nil,
+          thread_id: String.t() | nil,
+          workspace_id: String.t() | nil,
+          actor_id: String.t() | nil,
+          explicit: boolean(),
+          metadata: map()
+        }
+
+  @doc "Creates a channel scope."
+  @spec channel(String.t(), atom(), String.t(), keyword()) :: t()
+  def channel(bridge_id, adapter, channel_id, opts \\ []) do
+    new(:channel, bridge_id, adapter, channel_id, nil, opts)
+  end
+
+  @doc "Creates a thread scope that also permits parent-channel reads."
+  @spec thread(String.t(), atom(), String.t(), String.t(), keyword()) :: t()
+  def thread(bridge_id, adapter, channel_id, thread_id, opts \\ []) do
+    new(:thread, bridge_id, adapter, channel_id, thread_id, opts)
+  end
+
+  @doc "Creates a thread scope that permits only the exact thread."
+  @spec strict_thread(String.t(), atom(), String.t(), String.t(), keyword()) :: t()
+  def strict_thread(bridge_id, adapter, channel_id, thread_id, opts \\ []) do
+    new(:strict_thread, bridge_id, adapter, channel_id, thread_id, opts)
+  end
+
+  @doc "Creates an explicit workspace scope."
+  @spec workspace(String.t(), keyword()) :: t()
+  def workspace(workspace_id, opts \\ []) do
+    %__MODULE__{
+      kind: :workspace,
+      workspace_id: to_string(workspace_id),
+      actor_id: stringify(Keyword.get(opts, :actor_id)),
+      explicit: true,
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  @doc "Builds a scope from plain serialized data."
+  @spec from_map(map() | t()) :: t()
+  def from_map(%__MODULE__{} = scope), do: scope
+
+  def from_map(map) when is_map(map) do
+    kind = map |> get(:kind) |> normalize_kind()
+
+    %__MODULE__{
+      kind: kind,
+      bridge_id: stringify(get(map, :bridge_id)),
+      adapter: normalize_existing_atom(get(map, :adapter)),
+      channel_id: stringify(get(map, :channel_id)),
+      thread_id: stringify(get(map, :thread_id)),
+      workspace_id: stringify(get(map, :workspace_id)),
+      actor_id: stringify(get(map, :actor_id)),
+      explicit: get(map, :explicit) == true,
+      metadata: get(map, :metadata) || %{}
+    }
+  end
+
+  @doc "Converts a scope to a JSON-safe plain map."
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{} = scope) do
+    %{
+      "kind" => Atom.to_string(scope.kind),
+      "bridge_id" => scope.bridge_id,
+      "adapter" => stringify(scope.adapter),
+      "channel_id" => scope.channel_id,
+      "thread_id" => scope.thread_id,
+      "workspace_id" => scope.workspace_id,
+      "actor_id" => scope.actor_id,
+      "explicit" => scope.explicit,
+      "metadata" => scope.metadata
+    }
+  end
+
+  @doc "Infers the narrowest normal scope from a message or event context."
+  @spec inherit(map() | struct(), keyword()) :: t() | nil
+  def inherit(context, opts \\ []) when is_map(context) do
+    bridge_id = get(context, :bridge_id) || get(context, :instance_id)
+    adapter = get(context, :channel_type)
+    channel_id = get(context, :external_room_id) || get(context, :channel_id)
+    thread_id = get(context, :external_thread_id) || get(context, :thread_id)
+    actor_id = Keyword.get(opts, :actor_id) || get(context, :participant_id) || get(context, :external_user_id)
+
+    cond do
+      blank?(bridge_id) or blank?(adapter) or blank?(channel_id) ->
+        nil
+
+      not blank?(thread_id) ->
+        thread(to_string(bridge_id), normalize_existing_atom(adapter), to_string(channel_id), to_string(thread_id),
+          actor_id: actor_id
+        )
+
+      true ->
+        channel(to_string(bridge_id), normalize_existing_atom(adapter), to_string(channel_id), actor_id: actor_id)
+    end
+  end
+
+  @doc false
+  @spec bind_actor(t(), term()) :: t()
+  def bind_actor(%__MODULE__{} = scope, nil), do: scope
+  def bind_actor(%__MODULE__{} = scope, actor_id), do: %{scope | actor_id: stringify(actor_id)}
+
+  @doc false
+  @spec authorize(t(), map()) :: :ok | {:error, atom()}
+  def authorize(%__MODULE__{kind: :workspace, explicit: false}, _target),
+    do: {:error, :workspace_scope_not_explicit}
+
+  def authorize(%__MODULE__{kind: :workspace, workspace_id: nil}, _target),
+    do: {:error, :workspace_scope_not_explicit}
+
+  def authorize(%__MODULE__{kind: :workspace} = scope, target) do
+    if scope.workspace_id == target.workspace_id do
+      :ok
+    else
+      {:error, :out_of_scope}
+    end
+  end
+
+  def authorize(%__MODULE__{kind: :channel} = scope, target) do
+    authorize_common(scope, target)
+  end
+
+  def authorize(%__MODULE__{kind: :thread} = scope, target) do
+    with :ok <- authorize_common(scope, target) do
+      if is_nil(target.thread_id) or target.thread_id == scope.thread_id,
+        do: :ok,
+        else: {:error, :out_of_scope}
+    end
+  end
+
+  def authorize(%__MODULE__{kind: :strict_thread} = scope, target) do
+    with :ok <- authorize_common(scope, target) do
+      if is_binary(target.thread_id) and target.thread_id == scope.thread_id,
+        do: :ok,
+        else: {:error, :out_of_scope}
+    end
+  end
+
+  defp authorize_common(scope, target) do
+    if scope.bridge_id == target.bridge_id and scope.adapter == target.adapter and
+         scope.channel_id == target.channel_id do
+      :ok
+    else
+      {:error, :out_of_scope}
+    end
+  end
+
+  defp new(kind, bridge_id, adapter, channel_id, thread_id, opts) do
+    %__MODULE__{
+      kind: kind,
+      bridge_id: to_string(bridge_id),
+      adapter: adapter,
+      channel_id: to_string(channel_id),
+      thread_id: stringify(thread_id),
+      workspace_id: stringify(Keyword.get(opts, :workspace_id)),
+      actor_id: stringify(Keyword.get(opts, :actor_id)),
+      explicit: Keyword.get(opts, :explicit, false),
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  defp normalize_kind(value) when value in @kinds, do: value
+
+  defp normalize_kind(value) when is_binary(value) do
+    Enum.find(@kinds, fn kind -> Atom.to_string(kind) == value end) || raise ArgumentError, "invalid scope kind"
+  end
+
+  defp normalize_kind(_value), do: raise(ArgumentError, "invalid scope kind")
+
+  defp normalize_existing_atom(value) when is_atom(value), do: value
+
+  defp normalize_existing_atom(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> raise ArgumentError, "unknown adapter identifier"
+  end
+
+  defp get(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: to_string(value)
+  defp blank?(value), do: value in [nil, ""]
+end

--- a/test/jido_messaging/chat_actions_test.exs
+++ b/test/jido_messaging/chat_actions_test.exs
@@ -1,0 +1,802 @@
+defmodule Jido.Messaging.ChatActionsTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Chat.{Message, MessagePage, MessagingTarget, Response, Thread, ThreadPage}
+  alias Jido.Messaging.ChatActions
+  alias Jido.Messaging.ChatActions.{Policy, Scope}
+  alias Jido.Messaging.ChatActions.Reader.{FetchChannelMessages, FetchMessage, FetchThreadMessages}
+  alias Jido.Messaging.ChatActions.Messenger.{PostMessage, SendDirectMessage}
+  alias Jido.Messaging.ChatActions.Moderator.{DeleteMessage, EnsureSubscription}
+
+  defmodule FullAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :full
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def capabilities do
+      %{
+        send_message: :native,
+        post_message: :native,
+        post_channel_message: :native,
+        edit_message: :native,
+        delete_message: :native,
+        start_typing: :native,
+        fetch_metadata: :native,
+        fetch_thread: :native,
+        fetch_message: :native,
+        add_reaction: :native,
+        remove_reaction: :native,
+        open_dm: :native,
+        fetch_messages: :native,
+        fetch_channel_messages: :native,
+        list_threads: :native
+      }
+    end
+
+    @impl true
+    def send_message(room_id, text, opts) do
+      record(:send_message, [room_id, text, opts])
+      {:ok, %{external_message_id: "sent-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def post_message(room_id, payload, opts) do
+      record(:post_message, [room_id, payload, opts])
+      {:ok, %{external_message_id: "post-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def post_channel_message(room_id, text, opts) do
+      record(:post_channel_message, [room_id, text, opts])
+      {:ok, %{external_message_id: "channel-post-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def edit_message(room_id, message_id, text, opts) do
+      record(:edit_message, [room_id, message_id, text, opts])
+      {:ok, %{external_message_id: message_id, external_room_id: room_id}}
+    end
+
+    @impl true
+    def delete_message(room_id, message_id, opts) do
+      record(:delete_message, [room_id, message_id, opts])
+      :ok
+    end
+
+    @impl true
+    def start_typing(room_id, opts) do
+      record(:start_typing, [room_id, opts])
+      :ok
+    end
+
+    @impl true
+    def fetch_metadata(room_id, opts) do
+      record(:fetch_metadata, [room_id, opts])
+      {:ok, %{id: to_string(room_id), name: "Full room"}}
+    end
+
+    @impl true
+    def fetch_thread(room_id, opts) do
+      record(:fetch_thread, [room_id, opts])
+
+      {:ok,
+       %{
+         id: "full:#{room_id}:#{opts[:external_thread_id]}",
+         adapter_name: :full,
+         adapter: __MODULE__,
+         external_room_id: room_id,
+         external_thread_id: opts[:external_thread_id]
+       }}
+    end
+
+    @impl true
+    def fetch_message(room_id, message_id, opts) do
+      record(:fetch_message, [room_id, message_id, opts])
+
+      case message_id do
+        "credential-error" ->
+          {:error, {:api_error, %{access_token: "provider-secret-token"}}}
+
+        "sibling-message" ->
+          {:ok,
+           %{
+             external_message_id: message_id,
+             external_room_id: room_id,
+             external_thread_id: "thread-2",
+             text: "sibling"
+           }}
+
+        "thread-message" ->
+          {:ok,
+           %{
+             external_message_id: message_id,
+             external_room_id: room_id,
+             external_thread_id: "thread-1",
+             text: "thread"
+           }}
+
+        _other ->
+          {:ok, %{external_message_id: to_string(message_id), external_room_id: room_id, text: "hello"}}
+      end
+    end
+
+    @impl true
+    def fetch_messages(room_id, opts) do
+      record(:fetch_messages, [room_id, opts])
+      {:ok, %{messages: [%{id: "thread-1", external_room_id: room_id, text: "thread"}]}}
+    end
+
+    @impl true
+    def fetch_channel_messages(room_id, opts) do
+      record(:fetch_channel_messages, [room_id, opts])
+      {:ok, %{messages: [%{id: "channel-1", external_room_id: room_id, text: "channel"}]}}
+    end
+
+    @impl true
+    def list_threads(room_id, opts) do
+      record(:list_threads, [room_id, opts])
+      {:ok, %{threads: [%{id: "thread-1"}]}}
+    end
+
+    @impl true
+    def open_dm(user_id, opts) do
+      record(:open_dm, [user_id, opts])
+      {:ok, "dm-#{user_id}"}
+    end
+
+    @impl true
+    def add_reaction(room_id, message_id, emoji, opts) do
+      record(:add_reaction, [room_id, message_id, emoji, opts])
+      :ok
+    end
+
+    @impl true
+    def remove_reaction(room_id, message_id, emoji, opts) do
+      record(:remove_reaction, [room_id, message_id, emoji, opts])
+      :ok
+    end
+
+    def ensure_ingress_subscription(bridge_id, opts) do
+      record(:ensure_ingress_subscription, [bridge_id, opts])
+      {:ok, %{id: "sub-1", target_url: "https://example.test/hook"}}
+    end
+
+    def list_ingress_subscriptions(bridge_id, opts) do
+      record(:list_ingress_subscriptions, [bridge_id, opts])
+      {:ok, [%{id: "sub-1"}]}
+    end
+
+    def delete_ingress_subscription(bridge_id, subscription_id, opts) do
+      record(:delete_ingress_subscription, [bridge_id, subscription_id, opts])
+      {:ok, %{id: subscription_id}}
+    end
+
+    def lookup_user(query, opts) do
+      record(:lookup_user, [query, opts])
+      {:ok, %{id: query[:id], name: "Ada"}}
+    end
+
+    defp record(operation, args) do
+      if pid = Application.get_env(:jido_messaging, :chat_actions_test_pid) do
+        send(pid, {:provider_call, __MODULE__, operation, args})
+      end
+    end
+  end
+
+  defmodule ReadOnlyAdapter do
+    @behaviour Jido.Chat.Adapter
+
+    @impl true
+    def channel_type, do: :read_only
+
+    @impl true
+    def transform_incoming(_raw), do: {:error, :not_implemented}
+
+    @impl true
+    def capabilities, do: %{send_message: :native, fetch_message: :native}
+
+    @impl true
+    def send_message(room_id, text, opts) do
+      record(:send_message, [room_id, text, opts])
+      {:ok, %{external_message_id: "read-send-1", external_room_id: room_id}}
+    end
+
+    @impl true
+    def fetch_message(room_id, message_id, opts) do
+      record(:fetch_message, [room_id, message_id, opts])
+      {:ok, %{id: to_string(message_id), external_room_id: room_id, text: "read only"}}
+    end
+
+    defp record(operation, args) do
+      if pid = Application.get_env(:jido_messaging, :chat_actions_test_pid) do
+        send(pid, {:provider_call, __MODULE__, operation, args})
+      end
+    end
+  end
+
+  defmodule TestMessaging do
+    use Jido.Messaging, persistence: Jido.Messaging.Persistence.ETS
+  end
+
+  setup do
+    Application.put_env(:jido_messaging, :chat_actions_test_pid, self())
+    start_supervised!(TestMessaging)
+
+    {:ok, _} =
+      TestMessaging.put_bridge_config(%{
+        id: "full-main",
+        adapter_module: FullAdapter,
+        opts: %{
+          workspace_id: "workspace-1",
+          ingress: %{target_url: "https://trusted.example.test/hook"}
+        }
+      })
+
+    {:ok, _} =
+      TestMessaging.put_bridge_config(%{
+        id: "read-main",
+        adapter_module: ReadOnlyAdapter,
+        opts: %{workspace_id: "workspace-1"}
+      })
+
+    on_exit(fn -> Application.delete_env(:jido_messaging, :chat_actions_test_pid) end)
+    :ok
+  end
+
+  describe "capability-first action sets" do
+    test "builds presets and custom lists from two adapters" do
+      full = target("full-main", :full, "room-1")
+      read_only = target("read-main", :read_only, "room-1")
+
+      assert {:ok, full_reader} = ChatActions.actions_for(TestMessaging, full, :reader)
+      assert FetchMessage in full_reader
+      assert FetchChannelMessages in full_reader
+
+      assert {:ok, full_actions} = ChatActions.actions_for(TestMessaging, full, :all)
+      assert length(full_actions) == length(ChatActions.preset(:all))
+
+      for action <- ChatActions.preset(:all), prohibited <- [:credentials, :adapter_module, :client] do
+        refute Keyword.has_key?(action.schema().fields, prohibited)
+
+        target_schema = Keyword.fetch!(action.schema().fields, :target)
+        refute Keyword.has_key?(target_schema.fields, prohibited)
+      end
+
+      assert {:ok, read_only_reader} = ChatActions.actions_for(TestMessaging, read_only, :reader)
+      assert FetchMessage in read_only_reader
+      refute FetchChannelMessages in read_only_reader
+
+      assert {:ok, read_only_messenger} = ChatActions.actions_for(TestMessaging, read_only, :messenger)
+      assert PostMessage in read_only_messenger
+
+      assert {:ok, [FetchMessage]} =
+               ChatActions.actions_for(TestMessaging, read_only, [FetchMessage, DeleteMessage])
+    end
+
+    test "rejects unsupported work before a provider call" do
+      context = action_context(channel_scope("read-main", :read_only, "room-1"))
+
+      assert {:ok, %{status: :error, code: :unsupported_operation}} =
+               Jido.Exec.run(
+                 DeleteMessage,
+                 %{target: target_map("read-main", :read_only, "room-1"), message_id: "m-1"},
+                 context
+               )
+
+      refute_receive {:provider_call, ReadOnlyAdapter, :delete_message, _}
+    end
+  end
+
+  describe "reader operations and scope" do
+    test "returns canonical normalized models from adapter reads" do
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+
+      assert {:ok, %{status: :ok, data: %Message{id: "m-1"}}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :full, "room-1"), message_id: "m-1"},
+                 context
+               )
+
+      assert_receive {:provider_call, FullAdapter, :fetch_message, ["room-1", "m-1", opts]}
+      assert opts[:credentials] == %{}
+      refute Keyword.has_key?(FetchMessage.schema().fields, :credentials)
+
+      assert {:ok, %{status: :ok, data: %MessagePage{}}} =
+               Jido.Exec.run(FetchChannelMessages, %{target: target_map("full-main", :full, "room-1")}, context)
+    end
+
+    test "blocks cross-channel and spoofed adapter reads before provider access" do
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+
+      assert {:ok, %{status: :denied, code: :out_of_scope}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :full, "room-2"), message_id: "m-1"},
+                 context
+               )
+
+      assert {:ok, %{status: :error, code: :target_mismatch}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :read_only, "room-1"), message_id: "m-1"},
+                 context
+               )
+
+      refute_receive {:provider_call, _, :fetch_message, _}
+    end
+
+    test "strict thread rejects a sibling thread and its parent channel" do
+      scope = Scope.strict_thread("full-main", :full, "room-1", "thread-1", actor_id: "actor-1")
+      context = action_context(scope)
+
+      assert {:ok, %{status: :denied, code: :out_of_scope}} =
+               Jido.Exec.run(
+                 FetchThreadMessages,
+                 %{target: target_map("full-main", :full, "room-1", "thread-2")},
+                 context
+               )
+
+      assert {:ok, %{status: :denied, code: :out_of_scope}} =
+               Jido.Exec.run(FetchChannelMessages, %{target: target_map("full-main", :full, "room-1")}, context)
+
+      refute_receive {:provider_call, FullAdapter, _, _}
+    end
+
+    test "strict thread rejects channel-only work even when the target carries its thread" do
+      scope = Scope.strict_thread("full-main", :full, "room-1", "thread-1", actor_id: "actor-1")
+      policy = Policy.allow([:post_channel_message], actor: "actor-1", channel: "room-1")
+      context = action_context(scope, policy)
+      target = target_map("full-main", :full, "room-1", "thread-1")
+
+      assert {:ok, %{status: :denied, code: :out_of_scope}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Messenger.PostChannelMessage,
+                 %{target: target, text: "escape"},
+                 context
+               )
+
+      refute_receive {:provider_call, FullAdapter, :post_channel_message, _}
+    end
+
+    test "strict thread verifies message membership before reads and mutations" do
+      operations = [
+        {FetchMessage, :fetch_message, %{message_id: "sibling-message"}},
+        {Jido.Messaging.ChatActions.Moderator.EditMessage, :edit_message,
+         %{message_id: "sibling-message", text: "edited"}},
+        {DeleteMessage, :delete_message, %{message_id: "sibling-message"}},
+        {Jido.Messaging.ChatActions.Moderator.AddReaction, :add_reaction,
+         %{message_id: "sibling-message", emoji: "ok"}},
+        {Jido.Messaging.ChatActions.Moderator.RemoveReaction, :remove_reaction,
+         %{message_id: "sibling-message", emoji: "ok"}}
+      ]
+
+      action_names = Enum.map(operations, fn {_module, action, _params} -> action end)
+      scope = Scope.strict_thread("full-main", :full, "room-1", "thread-1", actor_id: "actor-1")
+      policy = Policy.allow(action_names, actor: "actor-1", channel: "room-1", thread: "thread-1")
+      context = action_context(scope, policy)
+      target = target_map("full-main", :full, "room-1", "thread-1")
+
+      for {action, provider_operation, params} <- operations do
+        assert {:ok, %{status: :denied, code: :out_of_scope}} =
+                 Jido.Exec.run(action, Map.put(params, :target, target), context)
+
+        assert_receive {:provider_call, FullAdapter, :fetch_message, ["room-1", "sibling-message", opts]}
+        refute Keyword.has_key?(opts, :thread_id)
+        refute Keyword.has_key?(opts, :external_thread_id)
+
+        if provider_operation != :fetch_message do
+          refute_receive {:provider_call, FullAdapter, ^provider_operation, _}
+        end
+      end
+
+      assert {:ok, %{status: :ok, data: %Message{id: "thread-message"}}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target, message_id: "thread-message"},
+                 context
+               )
+
+      assert_receive {:provider_call, FullAdapter, :fetch_message, ["room-1", "thread-message", _opts]}
+      refute_receive {:provider_call, FullAdapter, :fetch_message, ["room-1", "thread-message", _opts]}
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Moderator.EditMessage,
+                 %{target: target, message_id: "thread-message", text: "edited"},
+                 context
+               )
+
+      assert_receive {:provider_call, FullAdapter, :fetch_message, ["room-1", "thread-message", verify_opts]}
+      refute Keyword.has_key?(verify_opts, :thread_id)
+
+      assert_receive {:provider_call, FullAdapter, :edit_message, ["room-1", "thread-message", "edited", mutation_opts]}
+
+      assert mutation_opts[:thread_id] == "thread-1"
+      assert mutation_opts[:external_thread_id] == "thread-1"
+    end
+
+    test "participant lookup cannot replace the trusted adapter selector" do
+      {:ok, participant} =
+        TestMessaging.create_participant(%{
+          id: "participant-trusted-adapter",
+          type: :human,
+          identity: %{name: "Trusted Ada"},
+          external_ids: %{full: "trusted-user"}
+        })
+
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+
+      assert {:ok, %{status: :ok, data: ^participant}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Reader.LookupParticipant,
+                 %{
+                   target: target_map("full-main", :full, "room-1"),
+                   query: %{external_id: "trusted-user", channel: :read_only}
+                 },
+                 context
+               )
+    end
+
+    test "provider errors do not expose provider credentials" do
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+
+      assert {:ok, %{status: :error, code: :provider_error, details: %{reason: %{type: :api_error}}} = result} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :full, "room-1"), message_id: "credential-error"},
+                 context
+               )
+
+      refute inspect(result) =~ "provider-secret-token"
+    end
+
+    test "workspace reads require an explicit workspace scope" do
+      implicit = Scope.from_map(%{kind: :workspace, workspace_id: "workspace-1", explicit: false})
+      context = action_context(implicit)
+
+      assert {:ok, %{status: :denied, code: :workspace_scope_not_explicit}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :full, "room-1"), message_id: "m-1"},
+                 context
+               )
+
+      explicit = Scope.workspace("workspace-1", actor_id: "actor-1")
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 FetchMessage,
+                 %{target: target_map("full-main", :full, "room-1"), message_id: "m-1"},
+                 action_context(explicit)
+               )
+    end
+
+    test "inherits a thread scope from active normalized context" do
+      active_context = %{
+        bridge_id: "full-main",
+        channel_type: :full,
+        external_room_id: "room-1",
+        external_thread_id: "thread-1",
+        external_user_id: "actor-1"
+      }
+
+      context = ChatActions.context(TestMessaging, active_context)
+
+      assert {:ok, %{status: :ok, audit: %{scope_kind: :thread, actor_id: "actor-1"}}} =
+               Jido.Exec.run(
+                 FetchThreadMessages,
+                 %{target: target_map("full-main", :full, "room-1", "thread-1")},
+                 context
+               )
+    end
+
+    test "executes the remaining reader seams with normalized results" do
+      {:ok, participant} =
+        TestMessaging.create_participant(%{
+          id: "participant-1",
+          type: :human,
+          identity: %{name: "Ada"},
+          external_ids: %{full: "user-1"}
+        })
+
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+      thread_target = target_map("full-main", :full, "room-1", "thread-1")
+      room_target = target_map("full-main", :full, "room-1")
+
+      assert {:ok, %{status: :ok, data: %Thread{external_thread_id: "thread-1"}}} =
+               Jido.Exec.run(Jido.Messaging.ChatActions.Reader.FetchThread, %{target: thread_target}, context)
+
+      assert {:ok, %{status: :ok, data: %MessagePage{}}} =
+               Jido.Exec.run(FetchThreadMessages, %{target: thread_target}, context)
+
+      assert {:ok, %{status: :ok, data: %ThreadPage{}}} =
+               Jido.Exec.run(Jido.Messaging.ChatActions.Reader.ListThreads, %{target: room_target}, context)
+
+      assert {:ok, %{status: :ok, data: ^participant}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Reader.LookupParticipant,
+                 %{target: room_target, query: %{external_id: "user-1"}},
+                 context
+               )
+
+      workspace_context = action_context(Scope.workspace("workspace-1", actor_id: "actor-1"))
+
+      assert {:ok, %{status: :ok, data: %{id: "provider-user-1", name: "Ada"}}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Reader.LookupUser,
+                 %{target: room_target, query: %{id: "provider-user-1"}},
+                 workspace_context
+               )
+
+      assert {:ok, %{status: :ok, data: %Jido.Chat.ChannelInfo{id: "room-1"}}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Reader.FetchChannelMetadata,
+                 %{target: room_target},
+                 context
+               )
+    end
+  end
+
+  describe "write approval policy" do
+    test "matches an adapter-scoped allow rule and uses the text post fallback" do
+      policy =
+        Policy.allow([:post_message],
+          adapter: :read_only,
+          actor: "actor-1",
+          channel: "room-1"
+        )
+
+      context = action_context(channel_scope("read-main", :read_only, "room-1"), policy)
+
+      assert {:ok, %{status: :ok, data: %Response{external_message_id: "read-send-1"}}} =
+               Jido.Exec.run(
+                 PostMessage,
+                 %{target: target_map("read-main", :read_only, "room-1"), text: "fallback"},
+                 context
+               )
+
+      assert_receive {:provider_call, ReadOnlyAdapter, :send_message, ["room-1", "fallback", _opts]}
+    end
+
+    test "visible writes need approval by default and return audit context" do
+      context = action_context(channel_scope("full-main", :full, "room-1"))
+
+      assert {:ok,
+              %{
+                status: :approval_required,
+                code: :approval_required,
+                audit: %{action: :post_message, actor_id: "actor-1", bridge_id: "full-main"}
+              }} =
+               Jido.Exec.run(PostMessage, %{target: target_map("full-main", :full, "room-1"), text: "hello"}, context)
+
+      refute_receive {:provider_call, FullAdapter, :post_message, _}
+    end
+
+    test "allows only a narrow configured action and denies a matching action" do
+      policy =
+        Policy.new(%{
+          rules: [
+            %{
+              result: :allow,
+              actions: [:post_message],
+              adapters: [:full],
+              channels: ["room-1"],
+              actors: ["actor-1"]
+            },
+            %{result: :deny, actions: [:delete_message], actors: ["actor-1"]}
+          ]
+        })
+
+      context = action_context(channel_scope("full-main", :full, "room-1"), policy)
+
+      assert {:ok, %{status: :ok, data: %Response{external_message_id: "post-1"}}} =
+               Jido.Exec.run(PostMessage, %{target: target_map("full-main", :full, "room-1"), text: "hello"}, context)
+
+      assert_receive {:provider_call, FullAdapter, :post_message, _}
+
+      assert {:ok, %{status: :denied, code: :policy_denied}} =
+               Jido.Exec.run(
+                 DeleteMessage,
+                 %{target: target_map("full-main", :full, "room-1"), message_id: "m-1"},
+                 context
+               )
+
+      refute_receive {:provider_call, FullAdapter, :delete_message, _}
+    end
+
+    test "does not accept an actor identifier supplied by action parameters" do
+      policy = Policy.allow([:post_message], actor: "privileged-actor", channel: "room-1")
+      context = action_context(channel_scope("full-main", :full, "room-1"), policy)
+
+      assert {:ok, %{status: :approval_required, audit: %{actor_id: "actor-1"}}} =
+               Jido.Exec.run(
+                 PostMessage,
+                 %{
+                   target: target_map("full-main", :full, "room-1"),
+                   text: "spoof",
+                   actor_id: "privileged-actor"
+                 },
+                 context
+               )
+
+      refute_receive {:provider_call, FullAdapter, :post_message, _}
+    end
+
+    test "uses one trusted actor when a supplied scope has a different actor" do
+      scope = Scope.channel("full-main", :full, "room-1", actor_id: "privileged-actor")
+      policy = Policy.allow([:post_message], actor: "privileged-actor", channel: "room-1")
+
+      context =
+        ChatActions.context(TestMessaging, %{scope: scope, policy: policy, actor_id: "actor-1"})
+
+      assert context.chat_action.actor_id == "actor-1"
+      assert context.chat_action.scope.actor_id == "actor-1"
+
+      assert {:ok, %{status: :approval_required, audit: %{actor_id: "actor-1"}}} =
+               Jido.Exec.run(
+                 PostMessage,
+                 %{target: target_map("full-main", :full, "room-1"), text: "blocked"},
+                 context
+               )
+
+      refute_receive {:provider_call, FullAdapter, :post_message, _}
+    end
+
+    test "direct messages and subscription changes require explicit workspace and approval" do
+      narrow_policy =
+        Policy.new(%{
+          rules: [
+            %{result: :allow, actions: [:send_direct_message, :ensure_subscription], actors: ["actor-1"]}
+          ]
+        })
+
+      channel_context = action_context(channel_scope("full-main", :full, "room-1"), narrow_policy)
+
+      assert {:ok, %{status: :denied, code: :workspace_scope_required}} =
+               Jido.Exec.run(
+                 SendDirectMessage,
+                 %{target: target_map("full-main", :full, "room-1"), user_id: "user-1", text: "secret"},
+                 channel_context
+               )
+
+      workspace_context = action_context(Scope.workspace("workspace-1", actor_id: "actor-1"), narrow_policy)
+
+      assert {:ok, %{status: :ok, data: %Response{external_room_id: "dm-user-1"}}} =
+               Jido.Exec.run(
+                 SendDirectMessage,
+                 %{target: target_map("full-main", :full, "room-1"), user_id: "user-1", text: "secret"},
+                 workspace_context
+               )
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 EnsureSubscription,
+                 %{
+                   target: target_map("full-main", :full, "room-1"),
+                   target_url: "https://attacker.example.test/hook"
+                 },
+                 workspace_context
+               )
+
+      refute Keyword.has_key?(EnsureSubscription.schema().fields, :target_url)
+
+      assert_receive {:provider_call, FullAdapter, :ensure_ingress_subscription, ["full-main", subscription_opts]}
+      assert subscription_opts[:target_url] == "https://trusted.example.test/hook"
+    end
+
+    test "executes edit, delete, reaction, typing, channel-post, and subscription operations" do
+      actions = [
+        :post_channel_message,
+        :edit_message,
+        :delete_message,
+        :add_reaction,
+        :remove_reaction,
+        :delete_subscription
+      ]
+
+      policy = Policy.allow(actions, actor: "actor-1", channel: "room-1")
+      channel_context = action_context(channel_scope("full-main", :full, "room-1"), policy)
+      room_target = target_map("full-main", :full, "room-1")
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Messenger.PostChannelMessage,
+                 %{target: room_target, text: "channel"},
+                 channel_context
+               )
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Moderator.EditMessage,
+                 %{target: room_target, message_id: "m-1", text: "edited"},
+                 channel_context
+               )
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(DeleteMessage, %{target: room_target, message_id: "m-1"}, channel_context)
+
+      for action <- [
+            Jido.Messaging.ChatActions.Moderator.AddReaction,
+            Jido.Messaging.ChatActions.Moderator.RemoveReaction
+          ] do
+        assert {:ok, %{status: :ok}} =
+                 Jido.Exec.run(action, %{target: room_target, message_id: "m-1", emoji: "ok"}, channel_context)
+      end
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Messenger.StartTyping,
+                 %{target: room_target},
+                 channel_context
+               )
+
+      workspace_policy =
+        Policy.new(%{rules: [%{result: :allow, actions: [:delete_subscription], actors: ["actor-1"]}]})
+
+      workspace_context = action_context(Scope.workspace("workspace-1", actor_id: "actor-1"), workspace_policy)
+
+      assert {:ok, %{status: :ok, data: [_subscription]}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Moderator.ListSubscriptions,
+                 %{target: room_target},
+                 workspace_context
+               )
+
+      assert {:ok, %{status: :ok}} =
+               Jido.Exec.run(
+                 Jido.Messaging.ChatActions.Moderator.DeleteSubscription,
+                 %{target: room_target, subscription_id: "sub-1"},
+                 workspace_context
+               )
+    end
+  end
+
+  test "serializes scope and policy and preserves them through async action execution" do
+    scope = Scope.thread("full-main", :full, "room-1", "thread-1", actor_id: "actor-1")
+    policy = Policy.allow([:post_message], actor: "actor-1", channel: "room-1", thread: "thread-1")
+
+    assert scope == scope |> Scope.to_map() |> Jason.encode!() |> Jason.decode!() |> Scope.from_map()
+    assert policy == policy |> Policy.to_map() |> Jason.encode!() |> Jason.decode!() |> Policy.from_map()
+
+    context = action_context(scope, policy)
+    target = target_map("full-main", :full, "room-1", "thread-1")
+    async_ref = Jido.Exec.run_async(PostMessage, %{target: target, text: "async"}, context)
+
+    assert {:ok, %{status: :ok, audit: %{thread_id: "thread-1", actor_id: "actor-1"}}} =
+             Jido.Exec.Async.await(async_ref)
+
+    assert_receive {:provider_call, FullAdapter, :post_message, _}
+  end
+
+  defp action_context(scope, policy \\ Policy.default()) do
+    ChatActions.context(TestMessaging, %{scope: scope, policy: policy, actor_id: "actor-1"})
+  end
+
+  defp channel_scope(bridge_id, adapter, channel_id) do
+    Scope.channel(bridge_id, adapter, channel_id, actor_id: "actor-1")
+  end
+
+  defp target(bridge_id, channel_type, channel_id) do
+    MessagingTarget.for_room(channel_id, bridge_id: bridge_id, channel_type: channel_type)
+  end
+
+  defp target_map(bridge_id, channel_type, channel_id, thread_id \\ nil) do
+    target =
+      if thread_id do
+        MessagingTarget.for_thread(channel_id, thread_id,
+          bridge_id: bridge_id,
+          channel_type: channel_type
+        )
+      else
+        target(bridge_id, channel_type, channel_id)
+      end
+
+    Map.from_struct(target)
+  end
+end


### PR DESCRIPTION
## Summary

- Add reusable reader, messenger, and moderator `Jido.Action` sets in `jido_messaging`.
- Resolve adapters from canonical targets and filter actions with declared adapter capabilities.
- Add channel, thread, strict-thread, and explicit workspace authorization scopes.
- Require approval by default for visible writes and return typed denial, approval, success, and error results.
- Preserve scope and policy through serialized and asynchronous execution context.
- Keep provider clients and credentials out of action schemas and returned provider errors.

## Security Boundary

- Reject cross-channel, sibling-thread, parent-channel, and identifier-spoofing access before mutation.
- Verify message membership for thread-scoped reads and mutations.
- Force trusted adapter selectors for participant lookup.
- Read subscription callback destinations from trusted bridge configuration, not model input.
- Redact provider error details while retaining stable error types.

## Validation

- Focused action tests — 20 passed.
- Full test suite — 628 passed, 4 skipped, 13 excluded.
- Format, Credo, and Dialyzer — passed; Dialyzer reported 0 errors.
- `git diff --check` — passed.
- Doctor reaches only two unchanged `origin/main` documentation failures.
- Post-fix review `20260821-094517-8a784a1e` — ready to merge with no findings.

## Post-Deploy Monitoring & Validation

- Confirm reader, messenger, moderator, and custom action sets resolve against at least two adapters.
- Confirm unsupported actions and out-of-scope reads stop before provider calls.
- Confirm visible writes return approval-required unless a narrow allow rule matches.
- Watch audit records for actor, bridge, adapter, channel, and thread consistency.
- Watch provider errors for accidental credential or callback URL disclosure.

Related: agentjido/jido_chat#41
Related: agentjido/jido_chat#42

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
